### PR TITLE
Issue with updating media files when importing files

### DIFF
--- a/Jumoo.uSync.Core/Helpers/uSyncMediaFileMover.cs
+++ b/Jumoo.uSync.Core/Helpers/uSyncMediaFileMover.cs
@@ -67,7 +67,9 @@ namespace Jumoo.uSync.Core.Helpers
                         // if we've created a new file in umbraco, it will be in a new folder
                         // and the old current file will need to be deleted.
                         if (Directory.Exists(currentFile.DirectoryName))
-                            Directory.Delete(currentFile.DirectoryName);
+                           
+                                Directory.Delete(currentFile.DirectoryName, true);
+                           
                     }
                 }
                 else

--- a/Jumoo.uSync.Core/Helpers/uSyncMediaFileMover.cs
+++ b/Jumoo.uSync.Core/Helpers/uSyncMediaFileMover.cs
@@ -58,7 +58,7 @@ namespace Jumoo.uSync.Core.Helpers
                     {
                         string sourceFile = Path.GetFileName(file);
 
-                        using (FileStream s = new FileStream(sourceFile, FileMode.Open))
+                        using (FileStream s = new FileStream(file, FileMode.Open))
                         {
                             item.SetValue("umbracoFile", sourceFile, s);
                             changes = true;


### PR DESCRIPTION
In the uSyncMediaFileMover.ImportFile function, a file stream was being opened with just the file name instead of the full path to the file. I have switched out the reference to use the full file path.

At the same time, I also had trouble with it throwing an error when deleting the old directory if it wasn't empty, so have set the recursive variable on Directory.Delete.