### PR TITLE
Port today's v17 update: revive uSync.Community.DataTypeSerializers (#1052)

### DIFF
--- a/uSync.Community.DataTypeSerializers/CoreTypes/ContentPickerConfigSerializer.cs
+++ b/uSync.Community.DataTypeSerializers/CoreTypes/ContentPickerConfigSerializer.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using Umbraco.Cms.Core.Services;
 
+using uSync.Community.DataTypeSerializers;
 using uSync.Core.DataTypes;
 
-namespace uSync8.Community.DataTypeSerializers.CoreTypes;
+namespace uSync.Community.DataTypeSerializers.CoreTypes;
 
 public class ContentPickerConfigSerializer : SyncDataTypeSerializerBase, IConfigurationSerializer
 {
@@ -13,57 +15,31 @@ public class ContentPickerConfigSerializer : SyncDataTypeSerializerBase, IConfig
     { }
 
     public string Name => "ContentPickerNodeSerializer";
-
     public string[] Editors => ["Umbraco.ContentPicker"];
+
+    private const string _startNodeIdKey = "startNodeId";
 
     public override IDictionary<string, object> GetConfigurationExport(IDictionary<string, object> configuration)
     {
+        if (configuration.TryGetValue(_startNodeIdKey, out var startNodeId)
+            && Guid.TryParse(startNodeId.ToString(), out var startNodeGuid)
+            && TryGuidToEntityPath(startNodeGuid, out var entityPath))
+        {
+            configuration["startNodeId"] = entityPath;
+        }
+
         return base.GetConfigurationExport(configuration);
     }
 
     public override IDictionary<string, object> GetConfigurationImport(IDictionary<string, object> configuration)
     {
+        if (configuration.TryGetValue(_startNodeIdKey, out var startNodeId)
+            && startNodeId is string startNodePath
+            && TryPathToGuid(startNodePath, out var startNodeGuid))
+        {
+            configuration["startNodeId"] = startNodeGuid;
+        }
+
         return base.GetConfigurationImport(configuration);
     }
-
-    //public override string? SerializeConfig(object configuration)
-    //{
-
-    //    if (configuration is ContentPickerConfiguration pickerConfig)
-    //    {
-    //        var contentPickerConfig = new MappedPathConfigBase<ContentPickerConfiguration>();
-
-    //        contentPickerConfig.Config = new ContentPickerConfiguration()
-    //        {
-    //            IgnoreUserStartNodes = pickerConfig.IgnoreUserStartNodes,
-    //            //StartNodeId = null,
-    //            //ShowOpenButton = pickerConfig.ShowOpenButton
-    //        };
-
-    //        //if (pickerConfig.StartNodeId != null)
-    //        //    contentPickerConfig.MappedPath = UdiToEntityPath(pickerConfig.StartNodeId);
-
-    //        return base.SerializeConfig(contentPickerConfig);
-    //    }
-
-    //    return base.SerializeConfig(configuration);
-    //}
-
-
-    //public override object? DeserializeConfig(string config, Type configType)
-    //{
-    //    if (configType == typeof(ContentPickerConfiguration))
-    //    {
-    //        var mappedConfig =   config.DeserializeJson<MappedPathConfigBase<ContentPickerConfiguration>>();
-
-    //        //if (!string.IsNullOrWhiteSpace(mappedConfig.MappedPath))
-    //        //{
-    //        //    mappedConfig.Config.StartNodeId = PathToUdi(mappedConfig.MappedPath);
-    //        //}
-
-    //        return mappedConfig?.Config;
-    //    }
-
-    //    return base.DeserializeConfig(config, configType);
-    //}
 }

--- a/uSync.Community.DataTypeSerializers/CoreTypes/MNTPickerConfigSerializer.cs
+++ b/uSync.Community.DataTypeSerializers/CoreTypes/MNTPickerConfigSerializer.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
 
 using Umbraco.Cms.Core.Services;
 
 using uSync.Core.DataTypes;
+using uSync.Core.Extensions;
 
-namespace uSync8.Community.DataTypeSerializers.CoreTypes;
+namespace uSync.Community.DataTypeSerializers.CoreTypes;
 
 public class MNTPickerConfigSerializer : SyncDataTypeSerializerBase, IConfigurationSerializer
 {
@@ -16,64 +19,74 @@ public class MNTPickerConfigSerializer : SyncDataTypeSerializerBase, IConfigurat
 
     public string[] Editors => ["Umbraco.MultiNodeTreePicker"];
 
+    private const string _startNodeKey = "startNode";
+    private const string _idKey = "id";
+    private const string _dynamicRootKey = "dynamicRoot";
+    private const string _originKeyKey = "originKey";
+
     public override IDictionary<string, object> GetConfigurationExport(IDictionary<string, object> configuration)
     {
+        if (configuration.TryGetValue(_startNodeKey, out var startNodeValue)
+            && startNodeValue is not null
+            && startNodeValue.TryConvertToJsonObject(out var startNode))
+        {
+            TryMapNodeValue(startNode, _idKey, TryGuidToEntityPath);
+
+            if (startNode.TryGetPropertyAsObject(_dynamicRootKey, out var dynamicRoot))
+                TryMapNodeValue(dynamicRoot, _originKeyKey, TryGuidToEntityPath);
+
+            configuration[_startNodeKey] = startNode;
+        }
+
         return base.GetConfigurationExport(configuration);
     }
 
     public override IDictionary<string, object> GetConfigurationImport(IDictionary<string, object> configuration)
     {
+        if (configuration.TryGetValue(_startNodeKey, out var startNodeValue)
+            && startNodeValue is not null
+            && startNodeValue.TryConvertToJsonObject(out var startNode))
+        {
+            TryMapNodeValue(startNode, _idKey, TryPathToGuid);
+
+            if (startNode.TryGetPropertyAsObject(_dynamicRootKey, out var dynamicRoot))
+                TryMapNodeValue(dynamicRoot, _originKeyKey, TryPathToGuid);
+
+            configuration[_startNodeKey] = startNode;
+        }
+
         return base.GetConfigurationImport(configuration);
     }
 
-    //public override string SerializeConfig(object configuration)
-    //{
-    //    var MNTPMappedConfig = new MappedPathConfigBase<MultiNodePickerConfiguration>();
+    private delegate bool TryConvert<TResult>(Guid guid, out TResult result);
+    private delegate bool TryConvertBack(string value, out Guid guid);
 
-    //    if (configuration is MultiNodePickerConfiguration pickerConfig)
-    //    {
-    //        MNTPMappedConfig.Config = new MultiNodePickerConfiguration()
-    //        {
-    //            IgnoreUserStartNodes = pickerConfig.IgnoreUserStartNodes,
-    //            // Filter = pickerConfig.Filter,
-    //            MaxNumber = pickerConfig.MaxNumber,
-    //            MinNumber = pickerConfig.MinNumber,
-    //            // ShowOpen = pickerConfig.ShowOpen,
-    //            TreeSource = new MultiNodePickerConfigurationTreeSource()
-    //            {
-    //                ObjectType = pickerConfig.TreeSource.ObjectType,
-    //                StartNodeId = pickerConfig.TreeSource.StartNodeId,
-    //                StartNodeQuery = pickerConfig.TreeSource.StartNodeQuery
-    //            }
+    /// <summary>
+    ///  maps a guid property value to its entity path, if the property is present and holds a guid.
+    /// </summary>
+    private static bool TryMapNodeValue(JsonObject node, string propertyName, TryConvert<string> converter)
+    {
+        if (node.TryGetPropertyValue(propertyName, out var propertyValue) is false
+            || propertyValue is null) return false;
 
-    //        };
+        if (Guid.TryParse(propertyValue.ToString(), out var guid) is false) return false;
+        if (converter(guid, out var path) is false) return false;
 
-    //        if (pickerConfig?.TreeSource?.StartNodeId != null)
-    //        {
-    //            MNTPMappedConfig.MappedPath = UdiToEntityPath(pickerConfig.TreeSource.StartNodeId);
-    //        }
+        node[propertyName] = path;
+        return true;
+    }
 
-    //        return base.SerializeConfig(MNTPMappedConfig);
-    //    }
+    /// <summary>
+    ///  maps an entity path property value back to a guid, if the property is present and holds a path.
+    /// </summary>
+    private static bool TryMapNodeValue(JsonObject node, string propertyName, TryConvertBack converter)
+    {
+        if (node.TryGetPropertyValue(propertyName, out var propertyValue) is false
+            || propertyValue is null) return false;
 
-    //    return base.SerializeConfig(configuration);
-    //}
+        if (converter(propertyValue.ToString(), out var guid) is false) return false;
 
-
-    //public override object DeserializeConfig(string config, Type configType)
-    //{
-    //    if (configType == typeof(MultiNodePickerConfiguration))
-    //    {
-    //        var mappedConfig = config.DeserializeJson<MappedPathConfigBase<MultiNodePickerConfiguration>>();
-
-    //        if (!string.IsNullOrWhiteSpace(mappedConfig.MappedPath))
-    //        {
-    //            mappedConfig.Config.TreeSource.StartNodeId = PathToUdi(mappedConfig.MappedPath);
-    //        }
-
-    //        return mappedConfig.Config;
-    //    }
-
-    //    return base.DeserializeConfig(config, configType);
-    //}
+        node[propertyName] = guid;
+        return true;
+    }
 }

--- a/uSync.Community.DataTypeSerializers/CoreTypes/MediaPicker3ConfigSerializer.cs
+++ b/uSync.Community.DataTypeSerializers/CoreTypes/MediaPicker3ConfigSerializer.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 
 using Umbraco.Cms.Core.Services;
 
+using uSync.Community.DataTypeSerializers;
 using uSync.Core.DataTypes;
 
-namespace uSync8.Community.DataTypeSerializers.CoreTypes;
+namespace uSync.Community.DataTypeSerializers.CoreTypes;
 
 public class MediaPicker3ConfigSerializer : SyncDataTypeSerializerBase, IConfigurationSerializer
 {
@@ -16,56 +18,29 @@ public class MediaPicker3ConfigSerializer : SyncDataTypeSerializerBase, IConfigu
 
     public string[] Editors => ["Umbraco.MediaPicker3"];
 
-    public override IDictionary<string, object> GetConfigurationImport(IDictionary<string, object> configuration)
-    {
-        return base.GetConfigurationImport(configuration);
-    }
+    private const string _startNodeIdKey = "startNodeId";
 
     public override IDictionary<string, object> GetConfigurationExport(IDictionary<string, object> configuration)
     {
+        if (configuration.TryGetValue(_startNodeIdKey, out var startNodeId)
+            && Guid.TryParse(startNodeId?.ToString(), out var startNodeGuid)
+            && TryGuidToEntityPath(startNodeGuid, out var entityPath))
+        {
+            configuration[_startNodeIdKey] = entityPath;
+        }
+
         return base.GetConfigurationExport(configuration);
     }
 
-    //    public override string SerializeConfig(object configuration)
-    //    {
+    public override IDictionary<string, object> GetConfigurationImport(IDictionary<string, object> configuration)
+    {
+        if (configuration.TryGetValue(_startNodeIdKey, out var startNodeId)
+            && startNodeId is string startNodePath
+            && TryPathToGuid(startNodePath, out var startNodeGuid))
+        {
+            configuration[_startNodeIdKey] = startNodeGuid;
+        }
 
-    //        if (configuration is MediaPicker3Configuration pickerConfig)
-    //        {
-    //            var mediaPickerConfig = new MappedPathConfigBase<MediaPicker3Configuration>();
-    //            mediaPickerConfig.Config = new MediaPicker3Configuration()
-    //            {
-    //                EnableLocalFocalPoint = pickerConfig.EnableLocalFocalPoint,
-    //                Crops = pickerConfig.Crops,
-    //                Filter = pickerConfig.Filter,
-    //                IgnoreUserStartNodes = pickerConfig.IgnoreUserStartNodes,
-    //                Multiple = pickerConfig.Multiple,
-    //                ValidationLimit = pickerConfig.ValidationLimit
-    //            };
-
-    //            if (pickerConfig.StartNodeId != null)
-    //                mediaPickerConfig.MappedPath = UdiToEntityPath(pickerConfig.StartNodeId);
-    //            return base.SerializeConfig(mediaPickerConfig);
-    //        }
-
-    //        return base.SerializeConfig(configuration);
-
-    //    }
-
-
-    //    public override object DeserializeConfig(string config, Type configType)
-    //    {
-    //        if (configType == typeof(MediaPicker3Configuration))
-    //        {
-    //            var mappedConfig = config.DeserializeJson<MappedPathConfigBase<MediaPicker3Configuration>>();
-
-    //            if (!string.IsNullOrWhiteSpace(mappedConfig.MappedPath))
-    //            {
-    //                mappedConfig.Config.StartNodeId = PathToUdi(mappedConfig.MappedPath);
-    //            }
-
-    //            return mappedConfig.Config;
-    //        }
-
-    //        return base.DeserializeConfig(config, configType);
-    //    }
+        return base.GetConfigurationImport(configuration);
+    }
 }

--- a/uSync.Community.DataTypeSerializers/CoreTypes/RichTextConfigSerializer.cs
+++ b/uSync.Community.DataTypeSerializers/CoreTypes/RichTextConfigSerializer.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+using Umbraco.Cms.Core.Services;
+
+using uSync.Community.DataTypeSerializers;
+using uSync.Core.DataTypes;
+
+namespace uSync.Community.DataTypeSerializers.CoreTypes;
+
+public class RichTextConfigSerializer : SyncDataTypeSerializerBase, IConfigurationSerializer
+{
+    public RichTextConfigSerializer(IEntityService entityService)
+        : base(entityService)
+    { }
+
+    public string Name => "RichTextNodeSerializer";
+
+    public string[] Editors => ["Umbraco.RichText"];
+
+    private const string _mediaParentIdKey = "mediaParentId";
+
+    public override IDictionary<string, object> GetConfigurationExport(IDictionary<string, object> configuration)
+    {
+        if (configuration.TryGetValue(_mediaParentIdKey, out var mediaParentId)
+            && Guid.TryParse(mediaParentId?.ToString(), out var mediaParentGuid)
+            && TryGuidToEntityPath(mediaParentGuid, out var entityPath))
+        {
+            // other serializers for this editor (e.g. uSync.Core's RichTextEditorMigratingSerializer)
+            // may hand us a read-only dictionary, so copy before mutating.
+            configuration = new Dictionary<string, object>(configuration)
+            {
+                [_mediaParentIdKey] = entityPath
+            };
+        }
+
+        return base.GetConfigurationExport(configuration);
+    }
+
+    public override IDictionary<string, object> GetConfigurationImport(IDictionary<string, object> configuration)
+    {
+        if (configuration.TryGetValue(_mediaParentIdKey, out var mediaParentId)
+            && mediaParentId is string mediaParentPath
+            && TryPathToGuid(mediaParentPath, out var mediaParentGuid))
+        {
+            // other serializers for this editor (e.g. uSync.Core's RichTextEditorMigratingSerializer)
+            // may hand us a read-only dictionary, so copy before mutating.
+            configuration = new Dictionary<string, object>(configuration)
+            {
+                [_mediaParentIdKey] = mediaParentGuid
+            };
+        }
+
+        return base.GetConfigurationImport(configuration);
+    }
+}

--- a/uSync.Community.DataTypeSerializers/SyncDataTypeSerializerBase.cs
+++ b/uSync.Community.DataTypeSerializers/SyncDataTypeSerializerBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -8,7 +9,7 @@ using Umbraco.Extensions;
 
 using uSync.Core.DataTypes;
 
-namespace uSync8.Community.DataTypeSerializers;
+namespace uSync.Community.DataTypeSerializers;
 
 public abstract class SyncDataTypeSerializerBase : ConfigurationSerializerBase
 {
@@ -19,18 +20,25 @@ public abstract class SyncDataTypeSerializerBase : ConfigurationSerializerBase
         this.entityService = entityService;
     }
 
-    protected virtual string UdiToEntityPath(Udi udi)
+    protected virtual bool TryUdiToEntityPath(Udi? udi, out string entityPath)
     {
-        if (udi != null && udi is GuidUdi guidUdi)
-        {
-            var item = entityService.Get(guidUdi.Guid);
-            if (item != null)
-            {
-                var type = Umbraco.Cms.Core.Models.ObjectTypes.GetUdiType(item.NodeObjectType);
-                return type + ":" + GetItemPath(item);
-            }
-        }
-        return string.Empty;
+        entityPath = string.Empty;
+
+        if (udi is not GuidUdi guidUdi) return false;
+
+        return TryGuidToEntityPath(guidUdi.Guid, out entityPath);
+    }
+
+    protected virtual bool TryGuidToEntityPath(Guid guid, out string entityPath)
+    {
+        entityPath = string.Empty;
+
+        var item = entityService.Get(guid);
+        if (item == null) return false;
+
+        var type = ObjectTypes.GetUdiType(item.NodeObjectType);
+        entityPath = type + ":" + GetItemPath(item);
+        return true;
     }
 
     protected virtual string GetItemPath(IEntitySlim item)
@@ -46,9 +54,24 @@ public abstract class SyncDataTypeSerializerBase : ConfigurationSerializerBase
         return path + "/" + item.Name;
     }
 
-    protected virtual Udi? PathToUdi(string entityPath)
+    protected virtual bool TryPathToUdi(string entityPath, out Udi? udi)
     {
-        if (!entityPath.Contains(':')) return null;
+        udi = null;
+
+        if (!entityPath.Contains(':')) return false;
+        var entityType = entityPath.Substring(0, entityPath.IndexOf(':'));
+
+        if (!TryPathToGuid(entityPath, out var key)) return false;
+
+        udi = Udi.Create(entityType, key);
+        return true;
+    }
+
+    protected virtual bool TryPathToGuid(string entityPath, out Guid guid)
+    {
+        guid = Guid.Empty;
+
+        if (!entityPath.Contains(':')) return false;
 
         var entityType = entityPath.Substring(0, entityPath.IndexOf(':'));
         var objectType = UdiEntityTypeHelper.ToUmbracoObjectType(entityType);
@@ -61,28 +84,24 @@ public abstract class SyncDataTypeSerializerBase : ConfigurationSerializerBase
 
         foreach (var name in names)
         {
-            next = FindItem(parentId, name, objectType);
-            if (next == null) return null;
+            if (!TryFindItem(parentId, name, objectType, out next)) return false;
 
             parentId = next.Id;
         }
 
-        if (next != null)
-            return Udi.Create(entityType, next.Key);
+        if (next == null) return false;
 
-
-        return null;
+        guid = next.Key;
+        return true;
     }
 
-    protected IEntitySlim? FindItem(int parentId, string name, UmbracoObjectTypes objectType)
+
+    protected bool TryFindItem(int parentId, string name, UmbracoObjectTypes objectType, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEntitySlim? item)
     {
         var children = entityService.GetChildren(parentId, objectType);
-        if (children.Any())
-        {
-            return children.FirstOrDefault(x => x.Name.InvariantEquals(name));
-        }
 
-        return null;
+        item = children.FirstOrDefault(x => x.Name.InvariantEquals(name));
+        return item != null;
     }
 
 }


### PR DESCRIPTION
## Summary
- Cherry-picks 71a56d90...b6c74165's DataTypeSerializers change (Jumoo/uSync#1052) from v17/main forward to v18/main, per the v17->v18 forward-merge policy.
- Converts `SyncDataTypeSerializerBase`'s guid/path lookups to a Try* pattern and adds/updates config serializers (ContentPicker, MediaPicker3, MNTPicker, new RichTextConfigSerializer) that map node references to portable entity paths.

Note: a full `git merge origin/v17/main` currently produces 25+ conflicts because the prior v17->v18 sync (#1050) wasn't recorded as a real git merge (different commit SHAs for equivalent content), so git re-surfaces the whole divergent history rather than just new commits. This PR only ports today's new v17 commit; the broader history reconciliation is a separate task.

## Test plan
- [x] `dotnet build uSync.Community.DataTypeSerializers` succeeds
- [x] Full solution build / test suite