### PR TITLE
Fix GitVersion branch regex to match v17/main

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -5,7 +5,7 @@ branches:
   main:
     mode: ContinuousDeployment
     tag: ""
-    regex: ^v15\/main$
+    regex: ^v\d+\/main$
   pull-request:
     mode: ContinuousDeployment
 ignore:


### PR DESCRIPTION
## Summary
- The Build and Package workflow has been failing on `v17/main` since it was enabled there (#1056) with `GitVersion output is not valid JSON`.
- Root cause: `GitVersion.yml`'s `main` branch config regex was still `^v15\/main$`, so GitVersion couldn't match `v17/main`, found no branch to inherit config from, and threw `InvalidOperationException`.
- Fix: generalize the regex to `^v\d+\/main$` so it matches the current LTS branch and future ones without needing edits per version bump.

## Test plan
- [x] Ran `dotnet-gitversion` locally against this repo/config before the fix — reproduced the crash (`Gitversion could not determine which branch to treat as the development branch...`).
- [x] Ran it again after the fix — produced a valid version (`17.3.9-ci.4`).
- [ ] Confirm the "v16 - Build and Package." workflow run goes green on this PR/after merge.