### PR TITLE
Get template content from the template service, and fix the compiled-views fallback

### DIFF
--- a/uSync.BackOffice/SyncHandlers/Handlers/TemplateHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/TemplateHandler.cs
@@ -107,7 +107,8 @@ public class TemplateHandler : SyncHandlerLevelBase<ITemplate>, ISyncHandler, IS
     {
         if (_viewFileSystem is null) return string.Empty;
 
-        var templateFileName = _viewFileSystem.GetRelativePath(alias.Replace(" ", "") + ".cshtml");
+        // Umbraco names the view file from the alias verbatim, so we have to do the same.
+        var templateFileName = _viewFileSystem.GetRelativePath(alias + ".cshtml");
         if (templateFileName is null) return string.Empty;
         if (_viewFileSystem.FileExists(templateFileName) is false) return string.Empty;
 

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -1,6 +1,4 @@
-﻿using Lucene.Net.Queries.Function.ValueSources;
-
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -21,7 +19,6 @@ namespace uSync.Core.Serialization.Serializers;
 [SyncSerializer("D0E0769D-CCAE-47B4-AD34-4182C587B08A", "Template Serializer", uSyncConstants.Serialization.Template)]
 public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer<ITemplate>
 {
-    private readonly IShortStringHelper _shortStringHelper;
     private readonly IFileSystem? _viewFileSystem;
 
     private readonly ITemplateService _templateService;
@@ -34,6 +31,7 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
     public TemplateSerializer(
         IEntityService entityService,
         ILogger<TemplateSerializer> logger,
+        // shortStringHelper is no longer used, but is kept so we don't break the constructor signature.
         IShortStringHelper shortStringHelper,
         FileSystems fileSystems,
         IConfiguration configuration,
@@ -42,8 +40,6 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
         IUserIdKeyResolver userIdKeyResolver)
         : base(entityService, logger)
     {
-        _shortStringHelper = shortStringHelper;
-
         _viewFileSystem = fileSystems.MvcViewsFileSystem;
         _configuration = configuration;
         _capabilityChecker = capabilityChecker;
@@ -87,14 +83,16 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
         var alias = node.GetAlias();
         var name = node.Element("Name").ValueOrDefault(string.Empty);
 
-        var contentAttempt = GetContentForTemplate(node, options);
-        if (!contentAttempt) return SyncAttempt<ITemplate>.Fail(name, ChangeType.Import, contentAttempt.Exception?.Message ?? "Failed to get content");
-
         var details = new List<uSyncChange>();
 
         var item = await FindTemplateFromNodeAsync(node);
         if (item is null)
         {
+            // we only need the content when we are creating the template, when we are updating
+            // it either comes from the node (below) or it is already on disk.
+            var contentAttempt = await GetContentForTemplateAsync(node, options);
+            if (!contentAttempt) return SyncAttempt<ITemplate>.Fail(name, ChangeType.Import, contentAttempt.Exception?.Message ?? "Failed to get content");
+
             var userKey = await _userIdKeyResolver.GetAsync(options.UserId);
             var attempt = await _templateService.CreateAsync(
                 name,
@@ -152,8 +150,9 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
         return SyncAttempt<ITemplate>.Succeed(item.Name, item, ChangeType.Import, details);
     }
 
-    private Attempt<string?> GetContentForTemplate(XElement node, SyncSerializerOptions options)
+    private async Task<Attempt<string?>> GetContentForTemplateAsync(XElement node, SyncSerializerOptions options)
     {
+        // if the setup is configured this way, we get template content from the xml file directly. 
         if (ShouldGetContentFromNode(node, options))
         {
             if (logger.IsEnabled(LogLevel.Debug))
@@ -162,6 +161,32 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
             return Attempt.Succeed(GetContentFromConfig(node));
         }
 
+        // if not, try and fetch the content the way umbraco does (via the template service)
+        var templateFileName = node.GetAlias();
+        if (templateFileName.EndsWith(".cshtml", StringComparison.InvariantCultureIgnoreCase) is false)
+            templateFileName = $"{templateFileName}.cshtml";
+
+        // note: the template service returns Stream.Null (not null) when the file is missing,
+        // and an empty file tells us nothing - so both mean 'look somewhere else'.
+        var stream = await _templateService.GetFileContentStreamAsync(templateFileName);
+        if (stream is not null && stream != Stream.Null)
+        {
+            await using (stream)
+            {
+                using var sr = new StreamReader(stream);
+                var fileContent = await sr.ReadToEndAsync();
+
+                if (string.IsNullOrWhiteSpace(fileContent) is false)
+                {
+                    if (logger.IsEnabled(LogLevel.Debug))
+                        logger.LogDebug("Reading {path} contents from template service", templateFileName);
+
+                    return Attempt.Succeed(fileContent);
+                }
+            }
+        }
+
+        // if not - then old-school, attempt to get content from the viewFileSystem
         var templatePath = ViewPath(node.GetAlias());
         if (templatePath is not null && _viewFileSystem?.FileExists(templatePath) is true)
         {
@@ -171,7 +196,8 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
             return Attempt.Succeed(GetContentFromFile(templatePath));
         }
 
-        // isn't on disk, but might be compiled. --> 
+        // if we get here, we've failed to get the content from anywhere, so it might be missing or its 
+        // compiled into the site, and in some dll (although the template service should fetch this?)
 
         if (ViewsAreCompiled(options) is true)
         {
@@ -179,8 +205,14 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
             // if this finds the view it tells us that the view is somewhere else ? 
             if (logger.IsEnabled(LogLevel.Debug))
                 logger.LogDebug("Failed to find content, but UsingRazorViews so if Umbraco creates anyway, we will then delete the file");
-            
-            return Attempt.Succeed($"<!-- [uSyncMarker:{this.Id}]  template content - will be removed -->");
+
+            // internally Umbraco parses the content for the master (from the Layout value) so we
+            // need to fake that. 
+            var master = node.Element("Parent")?.ValueOrDefault(string.Empty);
+            var layout = string.IsNullOrWhiteSpace(master) ? "null" : $"\"{master}.cshtml\"";
+
+            return Attempt.Succeed($"@{{\n    Layout = {layout};\n}}\n" +
+                $"<!-- [uSyncMarker:{this.Id}]  template content - will be removed -->");
         }
 
         // template is missing and the views are not compiled , then we can't create.
@@ -197,37 +229,28 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
     /// <returns></returns>
     private bool ShouldGetContentFromNode(XElement node, SyncSerializerOptions options)
     {
-        if (_capabilityChecker != null
-            && _configuration != null
-            && _capabilityChecker.HasRuntimeMode)
+        // no content in the file, so there is nothing to take from it.
+        if (node.Element("Contents") is null) return false;
+
+        // on a version of Umbraco that has runtime modes, we don't import the content
+        // in Production, because the views will be compiled into the site.
+        if (_capabilityChecker.HasRuntimeMode && ViewsAreCompiled(options))
         {
-            if (node.Element("Contents") != null)
-            {
-                if (ViewsAreCompiled(options))
-                {
-                    if (logger.IsEnabled(LogLevel.Debug))
-                        logger.LogDebug("Template contents will not be imported because site is running in Production mode");
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug("Template contents will not be imported because site is running in Production mode");
 
-                    return false;
-                }
-
-                // else (we have content - not running in Production) 
-                return true;
-            }
-
-            // else (we don't have content it doesn't matter)
             return false;
         }
 
-        // default 
-        return node.Element("Contents") != null;
-        // && options.GetSetting(uSyncConstants.Conventions.IncludeContent, false);
+        // note: we don't check the IncludeContent setting here - that setting controls
+        // whether we *export* the content, if it's in the file we will import it.
+        return true;
     }
 
     public static string GetContentFromConfig(XElement node)
         => node.Element("Contents").ValueOrDefault(string.Empty);
 
-    public string GetContentFromFile(string templatePath)
+    private string GetContentFromFile(string templatePath)
     {
         try
         {
@@ -238,29 +261,18 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
                 return System.IO.File.ReadAllText(templateFilePath);
             }
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
+            // any failure here is not fatal, we fall back to the filesystem provider below.
             logger.LogWarning(ex, "Error reading template, will read from filesystem provider instead");
         }
-        
+
         // via the file system, which does work, but occasionaly it locks.
-        var content = "";
-        using (var stream = _viewFileSystem?.OpenFile(templatePath))
-        {
-            if (stream is null) return content;
+        using var stream = _viewFileSystem?.OpenFile(templatePath);
+        if (stream is null) return string.Empty;
 
-            using (var sr = new StreamReader(stream))
-            {
-                content = sr.ReadToEnd();
-                sr.Close();
-                sr.Dispose();
-            }
-
-            stream.Close();
-            stream.Dispose();
-        }
-
-        return content;
+        using var sr = new StreamReader(stream);
+        return sr.ReadToEnd();
     }
 
     public override async Task<SyncAttempt<ITemplate>> DeserializeSecondPassAsync(ITemplate item, XElement node, SyncSerializerOptions options)
@@ -390,19 +402,10 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
     public override string ItemAlias(ITemplate item)
         => item.Alias;
 
-    /// <summary>
-    ///  we clean the content out of the template,
-    ///  We don't care if the content has changed during a normal serialization
-    /// </summary>
-    protected override XElement CleanseNode(XElement node)
-    {
-        node.Element("Content")?.Remove();
-        return base.CleanseNode(node);
-    }
-
-
+    // Umbraco names the view file from the alias verbatim (see TemplateRepository.SetVirtualPath)
+    // so we have to do the same, or we look for/delete the wrong file for aliases with spaces.
     private string? ViewPath(string alias)
-        => _viewFileSystem?.GetRelativePath(alias.Replace(" ", "") + ".cshtml");
+        => _viewFileSystem?.GetRelativePath(alias + ".cshtml");
 
     private bool ViewsAreCompiled(SyncSerializerOptions options)
         => _configuration.IsUmbracoRunningInProductionMode()

--- a/uSync.Tests/Serializers/TemplateSerializerTests.cs
+++ b/uSync.Tests/Serializers/TemplateSerializerTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
@@ -29,9 +31,8 @@ using uSync.Core.Serialization.Serializers;
 namespace uSync.Tests.Serializers;
 
 /// <summary>
-///  guards against #1044 - a failed template create used to be reported as a
-///  hardcoded "Failed to create template" with no exception/status, hiding
-///  why the import failed (e.g. only reproducible on IIS/Production).
+///  tests for importing templates - how we report failures, and how we get
+///  the content for a template when there is no .cshtml file on disk.
 /// </summary>
 [TestFixture]
 public class TemplateSerializerTests
@@ -80,6 +81,12 @@ public class TemplateSerializerTests
         ioHelper.Setup(x => x.ResolveUrl(It.IsAny<string>())).Returns<string>(path => "/" + path.TrimStart('~', '/'));
 #pragma warning restore CS0618
 
+        // PhysicalFileSystem uses this to check a path is inside its root - without it every
+        // path looks like it's outside the root, and FileExists throws instead of returning false.
+        ioHelper.Setup(x => x.PathStartsWith(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<char[]>()))
+            .Returns((string path, string root, char[] separators)
+                => path.StartsWith(root, StringComparison.OrdinalIgnoreCase));
+
         return new FileSystems(
             Mock.Of<ILoggerFactory>(),
             ioHelper.Object,
@@ -87,13 +94,29 @@ public class TemplateSerializerTests
             hostingEnvironment.Object);
     }
 
-    private static XElement BuildTemplateNode(Guid key, string alias, string name)
-        => new XElement("Template",
+    /// <summary>
+    ///  build a template node as it would appear in a .config file. Contents is optional -
+    ///  it's only in the file when the IncludeContent setting is on.
+    /// </summary>
+    private static XElement BuildTemplateNode(Guid key, string alias, string name, string parent = null, string contents = null)
+    {
+        var node = new XElement("Template",
             new XAttribute(uSyncConstants.Xml.Key, key),
             new XAttribute(uSyncConstants.Xml.Alias, alias),
             new XElement("Name", name),
-            new XElement("Contents", new XCData("@{ Layout = null; }")));
+            new XElement("Parent", parent ?? string.Empty));
 
+        if (contents is not null)
+            node.Add(new XElement("Contents", new XCData(contents)));
+
+        return node;
+    }
+
+    /// <summary>
+    ///  guards against #1044 - a failed template create used to be reported as a
+    ///  hardcoded "Failed to create template" with no exception/status, hiding
+    ///  why the import failed (e.g. only reproducible on IIS/Production).
+    /// </summary>
     [Test]
     public async Task Create_WhenTemplateServiceFails_ReturnsStatusAndException()
     {
@@ -105,7 +128,7 @@ public class TemplateSerializerTests
             .Setup(x => x.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid?>()))
             .ReturnsAsync(Attempt<ITemplate, TemplateOperationStatus>.Fail(TemplateOperationStatus.DuplicateAlias));
 
-        var node = BuildTemplateNode(Guid.NewGuid(), "linkTreeNew", "LinkTreeNew");
+        var node = BuildTemplateNode(Guid.NewGuid(), "linkTreeNew", "LinkTreeNew", contents: "@{ Layout = null; }");
 
         // act
         var result = await _serializer.DeserializeAsync(node, new SyncSerializerOptions());
@@ -132,10 +155,146 @@ public class TemplateSerializerTests
             .Setup(x => x.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid?>()))
             .ReturnsAsync(Attempt<ITemplate, TemplateOperationStatus>.Succeed(TemplateOperationStatus.Success, created));
 
-        var node = BuildTemplateNode(Guid.NewGuid(), "linkTreeNew", "LinkTreeNew");
+        var node = BuildTemplateNode(Guid.NewGuid(), "linkTreeNew", "LinkTreeNew", contents: "@{ Layout = null; }");
 
         var result = await _serializer.DeserializeAsync(node, new SyncSerializerOptions());
 
         Assert.That(result.Success, Is.True);
     }
+
+    #region No template file on disk
+
+    /// <summary>
+    ///  when the views are compiled into the site, there is no .cshtml on disk to read, so we
+    ///  hand Umbraco a placeholder. Umbraco works the parent out by parsing the Layout value
+    ///  out of that content, so the placeholder has to be something its parser understands.
+    /// </summary>
+    [Test]
+    public async Task Create_WhenNoFileOnDiskAndTemplateHasParent_PlaceholderContentSetsTheMaster()
+    {
+        // arrange: no files on disk, and the views are compiled (razor views mode).
+        var created = SetupTemplateServiceWithNoFilesOnDisk();
+        var options = RazorViewOptions();
+
+        // act: the parent has to exist before the child can reference it.
+        var parentResult = await _serializer.DeserializeAsync(
+            BuildTemplateNode(Guid.NewGuid(), "master", "Master"), options);
+
+        var childResult = await _serializer.DeserializeAsync(
+            BuildTemplateNode(Guid.NewGuid(), "childOfMaster", "Child Of Master", parent: "master"), options);
+
+        // assert: both imported, and the content we sent for the child parses back to the parent
+        // alias using Umbraco's own parser - which is how the master template actually gets set.
+        var childContent = created["childOfMaster"];
+        var parsedMaster = new TemplateContentParserService().MasterTemplateAlias(childContent);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parentResult.Success, Is.True);
+            Assert.That(childResult.Success, Is.True);
+            Assert.That(parsedMaster, Is.EqualTo("master"));
+
+            // and it's marked, so the second pass knows to delete the file Umbraco writes out.
+            Assert.That(childContent, Does.Contain($"[uSyncMarker:{_serializer.Id}]"));
+        });
+    }
+
+    /// <summary>
+    ///  same path, but for a root template - the placeholder should tell Umbraco there is
+    ///  no master, rather than pointing it at a template called "".
+    /// </summary>
+    [Test]
+    public async Task Create_WhenNoFileOnDiskAndTemplateHasNoParent_PlaceholderContentSetsNoMaster()
+    {
+        var created = SetupTemplateServiceWithNoFilesOnDisk();
+
+        var result = await _serializer.DeserializeAsync(
+            BuildTemplateNode(Guid.NewGuid(), "master", "Master"), RazorViewOptions());
+
+        var content = created["master"];
+        var parsedMaster = new TemplateContentParserService().MasterTemplateAlias(content);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.True);
+            Assert.That(parsedMaster, Is.Null);
+            Assert.That(content, Does.Contain($"[uSyncMarker:{_serializer.Id}]"));
+        });
+    }
+
+    /// <summary>
+    ///  when the views are not compiled a missing file is a genuine error - we can't create a
+    ///  template from nothing. Umbraco's template service hands back Stream.Null (not null) for
+    ///  a file that isn't there, so we have to spot that or we silently create empty templates.
+    /// </summary>
+    [Test]
+    public async Task Create_WhenNoFileOnDiskAndViewsAreNotCompiled_FailsWithMissingFile()
+    {
+        SetupTemplateServiceWithNoFilesOnDisk();
+
+        // note: no UsingRazorViews setting this time.
+        var result = await _serializer.DeserializeAsync(
+            BuildTemplateNode(Guid.NewGuid(), "orphan", "Orphan"), new SyncSerializerOptions());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Message, Does.Contain("missing"));
+        });
+    }
+
+    /// <summary>
+    ///  stands in for a site with no .cshtml files on disk (they are compiled into the site),
+    ///  and remembers what we create so a child import can find its parent.
+    /// </summary>
+    /// <returns>the content we passed to the template service, keyed by alias.</returns>
+    private Dictionary<string, string> SetupTemplateServiceWithNoFilesOnDisk()
+    {
+        var templates = new Dictionary<string, ITemplate>(StringComparer.InvariantCultureIgnoreCase);
+        var content = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+
+        // this is what Umbraco's TemplateRepository returns when the file isn't there.
+        _templateServiceMock.Setup(x => x.GetFileContentStreamAsync(It.IsAny<string>()))
+            .ReturnsAsync(Stream.Null);
+
+        _templateServiceMock.Setup(x => x.GetAsync(It.IsAny<string>()))
+            .ReturnsAsync((string alias) => templates.TryGetValue(alias, out var found) ? found : null);
+
+        _templateServiceMock.Setup(x => x.GetAsync(It.IsAny<Guid>()))
+            .ReturnsAsync((Guid key) =>
+            {
+                foreach (var template in templates.Values)
+                {
+                    if (template.Key == key) return template;
+                }
+                return null;
+            });
+
+        _templateServiceMock
+            .Setup(x => x.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid?>()))
+            .ReturnsAsync((string name, string alias, string templateContent, Guid userKey, Guid? key) =>
+            {
+                var template = new Template(Mock.Of<IShortStringHelper>(), name, alias)
+                {
+                    Content = templateContent
+                };
+
+                if (key is not null) template.Key = key.Value;
+
+                templates[alias] = template;
+                content[alias] = templateContent;
+
+                return Attempt<ITemplate, TemplateOperationStatus>.Succeed(TemplateOperationStatus.Success, template);
+            });
+
+        return content;
+    }
+
+    private static SyncSerializerOptions RazorViewOptions()
+        => new SyncSerializerOptions(new Dictionary<string, object>
+        {
+            [uSyncConstants.DefaultSettings.UsingRazorViews] = true
+        });
+
+    #endregion
 }


### PR DESCRIPTION
## What

When importing a template, we now ask Umbraco's `ITemplateService` for the file content first — the way Umbraco itself does it — before falling back to the view filesystem, and finally to a placeholder when the views are compiled into the site.

Getting that fallback chain to actually work needed two fixes:

**`GetFileContentStreamAsync` never returns null.** `TemplateRepository.GetFileContentStream` hands back `Stream.Null` when the file is missing (the signature is `Task<Stream>`, not `Task<Stream?>`). Checking for `null` meant we always took the "found it" branch, read an empty string, and created the template with no content. The view filesystem fallback and the compiled-views placeholder below it were unreachable, and a genuinely missing template file was silently imported as an empty template rather than failing with the "local file is missing" warning.

**The placeholder wasn't parseable.** Umbraco derives the master template by running `TemplateContentParserService` over the content, and its regex — `\s*Layout\s*=\s*"?(?<layout>[\w\s\.]*)"?;` — requires the trailing semi-colon. `{ Layout = "master" }` never matched, so the parent was never set on a template created this way. It's now written as valid razor:

```razor
@{
    Layout = "master.cshtml";
}
<!-- [uSyncMarker:...] template content - will be removed -->
```

Root templates get `Layout = null;` instead of pointing Umbraco at a template called `""`.

Also aligns `ViewPath` (and the equivalent in `TemplateHandler`) with how Umbraco names the view file — the alias verbatim, see `TemplateRepository.SetVirtualPath` — rather than stripping spaces, so we don't look for, or delete, the wrong file for an alias containing a space.

## Tidy-ups in the same files

- **Removed the `CleanseNode` override.** It removed a `"Content"` element, but the element is `"Contents"` — it has never done anything in any shipped version. Rather than "fix" the name, it's deleted: `TemplateTracker` explicitly tracks `/Contents`, so making the strip work would have the change hash ignore a change the tracker reports. Behaviour is unchanged; the dead code is gone.
- Dropped the unused `_shortStringHelper` field. The constructor parameter stays so the signature isn't broken.
- Flattened `ShouldGetContentFromNode` — it had null checks on non-nullable injected services. All four input combinations give the same answers as before.
- `GetContentFromFile` is now `private` (nothing in OpenSource or Products calls it) with tidier stream disposal.
- Moved the content fetch inside the create branch — the update path was paying for a filesystem read it discarded, and could fail an import over a file it didn't need.
- Removed a stray `using Lucene.Net.Queries.Function.ValueSources;`.

## Tests

Three new tests in `TemplateSerializerTests`, covering the no-file-on-disk path: creating a child template whose parent must be resolved from the placeholder, the root-template case, and the views-not-compiled case that should fail rather than silently create an empty template.

The parent test asserts the generated content parses back to `"master"` using Umbraco's real `TemplateContentParserService`, rather than re-implementing the regex — that parse is the actual mechanism by which the master gets set.

Both bugs above are covered: reverting the fixes fails these tests with `Expected: "master" But was: null` / content `<string.Empty>`, and `Expected: False But was: True` with message `"Created"`.

Full suite: 144 passed, 0 failed.

## Note for reviewers

`BuildFileSystems` in the test fixture now sets up `IIOHelper.PathStartsWith`. These are the first tests to reach `_viewFileSystem.FileExists`, and `PhysicalFileSystem.GetFullPath` uses that call to check a path is inside its root — unmocked it returns `false`, so every path looked out-of-root and `FileExists` threw `UnauthorizedAccessException` instead of returning false. Test-harness gap, not a product issue, but worth knowing for future tests that touch the view filesystem.

`TemplateSerializer.cs` exists in `v18/main` with the same code, so this needs forward-porting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
