### PR TITLE
Structured diff for JSON/block changes in the change view

### DIFF
--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/index.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './usync-action-box.js';
 export * from './usync-progress-box.js';
 export * from './usync-results-view.js';
 export * from './usync-change-view.js';
+export * from './usync-change-detail.js';
 export * from './usync-results-group-view.js';
 export * from './usync-result-row.js';
 export * from './usync-sync-file-info-view.js';

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-change-detail.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-change-detail.ts
@@ -1,0 +1,814 @@
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import {
+	type PropertyValues,
+	classMap,
+	css,
+	customElement,
+	html,
+	nothing,
+	property,
+	state,
+	styleMap,
+	when,
+} from '@umbraco-cms/backoffice/external/lit';
+import '@umbraco-cms/backoffice/components';
+import { diffWords, type UmbDiffChange } from '@umbraco-cms/backoffice/utils';
+import { ChangeDetailType, type USyncChange } from '../api';
+import {
+	USYNC_DIFF_LIMITS,
+	classifyChange,
+	collapseUnchanged,
+	diffJsonValues,
+	diffTextLines,
+	formatDiffPath,
+	formatLeafValue,
+	parseChangeName,
+	prettyJson,
+	type USyncChangeLabel,
+	type USyncClassifiedChange,
+	type USyncJsonDiffResult,
+	type USyncLeafChange,
+	type USyncLineDiffBlock,
+	type USyncLineDiffRow,
+} from '../utils/diff/index.js';
+
+/**
+ * Renders a single `USyncChange` detail as an expandable row, using the
+ * strategy chosen by `classifyChange` to pick a compact, readable diff
+ * rather than a wall of pretty-printed JSON.
+ */
+@customElement('usync-change-detail')
+export class uSyncChangeDetail extends UmbLitElement {
+	@property({ type: Object })
+	detail?: USyncChange;
+
+	@property({ type: Boolean, reflect: true })
+	open = false;
+
+	@state()
+	private _classified?: USyncClassifiedChange;
+
+	@state()
+	private _json?: USyncJsonDiffResult;
+
+	@state()
+	private _lines?: USyncLineDiffBlock[];
+
+	@state()
+	private _lineDegraded = false;
+
+	@state()
+	private _label?: USyncChangeLabel;
+
+	@state()
+	private _showRaw = false;
+
+	private _expandedRuns = new Set<number>();
+	private _expandedLeaves = new Set<number>();
+
+	// Diffing happens here, and only here - `render()` runs on every property
+	// change (including a plain expand/collapse click), so computing the
+	// diff there would re-diff on every toggle instead of once per detail.
+	protected willUpdate(changed: PropertyValues<this>) {
+		if (!changed.has('detail') || !this.detail) return;
+
+		const detail = this.detail;
+
+		this._label = parseChangeName(detail.name);
+		this._classified = classifyChange(detail);
+		this._json =
+			this._classified.strategy === 'json'
+				? diffJsonValues(this._classified.oldJson, this._classified.newJson)
+				: undefined;
+
+		if (this._classified.strategy === 'lines') {
+			const lineDiff = diffTextLines(this._classified.oldText, this._classified.newText);
+			this._lines = collapseUnchanged(lineDiff.rows);
+			this._lineDegraded = lineDiff.degraded;
+		} else {
+			this._lines = undefined;
+			this._lineDegraded = false;
+		}
+
+		this._expandedRuns.clear();
+		this._expandedLeaves.clear();
+		this._showRaw = false;
+
+		if (detail.success === false) {
+			this.open = true;
+		}
+	}
+
+	#toggleOpen() {
+		this.open = !this.open;
+	}
+
+	#toggleRun(index: number) {
+		if (this._expandedRuns.has(index)) {
+			this._expandedRuns.delete(index);
+		} else {
+			this._expandedRuns.add(index);
+		}
+		this.requestUpdate();
+	}
+
+	#toggleLeaf(index: number) {
+		if (this._expandedLeaves.has(index)) {
+			this._expandedLeaves.delete(index);
+		} else {
+			this._expandedLeaves.add(index);
+		}
+		this.requestUpdate();
+	}
+
+	#toggleRaw() {
+		this._showRaw = !this._showRaw;
+	}
+
+	#copyPath() {
+		if (!this.detail) return;
+		navigator.clipboard?.writeText(this.detail.path)?.catch(() => undefined);
+	}
+
+	#isExpandable(strategy: USyncClassifiedChange['strategy']): boolean {
+		return strategy !== 'scalar' && strategy !== 'skip';
+	}
+
+	#lineCounts(): { added: number; removed: number } {
+		let added = 0;
+		let removed = 0;
+		for (const block of this._lines ?? []) {
+			if (block.type !== 'row') continue;
+			if (block.row.type === 'add') added++;
+			else if (block.row.type === 'remove') removed++;
+		}
+		return { added, removed };
+	}
+
+	render() {
+		if (!this.detail || !this._classified) return nothing;
+
+		const detail = this.detail;
+		const classified = this._classified;
+		const failed = detail.success === false;
+		const expandable = this.#isExpandable(classified.strategy);
+		const isOpen = this.open;
+
+		return html`
+			<div class=${classMap({ 'change-row': true, danger: failed })}>
+				<div
+					class=${classMap({ summary: true, expanded: isOpen, static: !expandable })}
+					@click=${expandable ? this.#toggleOpen : undefined}>
+					<div class="summary-left">
+						${when(
+							failed,
+							() => html`<umb-icon name="icon-alert" class="color-red"></umb-icon>`,
+						)}
+						${when(
+							this._label?.prefix,
+							() =>
+								html`<span class="prefix"
+									>${this.localize.term('uSync_changeProperty')}</span
+								>`,
+						)}
+						<span class="label" title=${detail.path}
+							>${this._label?.label || detail.name}</span
+						>
+						${when(
+							this._label?.culture,
+							() =>
+								html`<uui-tag size="s" look="secondary"
+									>${this._label!.culture}</uui-tag
+								>`,
+						)}
+					</div>
+					<div class="summary-right">
+						<span class=${classMap({ danger: classified.strategy === 'notice' })}
+							>${this.#renderSummary(classified)}</span
+						>
+						${when(
+							expandable,
+							() =>
+								html`<uui-icon
+									name="icon-play"
+									class=${classMap({ expanded: isOpen })}></uui-icon>`,
+						)}
+					</div>
+				</div>
+				${when(
+					isOpen && expandable,
+					() => html`
+						<div class="body">
+							${this.#renderBody(classified)}
+							<div class="path-line">
+								<span class="muted"
+									>${this.localize.term('uSync_diffPath', detail.path)}</span
+								>
+								<div class="path-line-actions">
+									${when(
+										classified.strategy === 'json',
+										() => html`
+											<uui-button look="text" compact @click=${this.#toggleRaw}>
+												${this._showRaw
+													? this.localize.term('uSync_diffHideRaw')
+													: this.localize.term('uSync_diffShowRaw')}
+											</uui-button>
+										`,
+									)}
+									<uui-button
+										look="text"
+										compact
+										label=${this.localize.term('uSync_diffCopyPath')}
+										@click=${this.#copyPath}>
+										<uui-icon name="icon-documents"></uui-icon>
+									</uui-button>
+								</div>
+							</div>
+						</div>
+					`,
+				)}
+			</div>
+		`;
+	}
+
+	#renderSummary(c: USyncClassifiedChange) {
+		switch (c.strategy) {
+			case 'scalar':
+				return html`<span class="inline-change"
+					><del>${c.oldText}</del> → <ins>${c.newText}</ins></span
+				>`;
+			case 'json': {
+				const diff = this._json;
+				if (!diff) return nothing;
+				if (diff.truncated) {
+					return this.localize.term(
+						'uSync_diffChangeCapped',
+						diff.changes.length,
+						diff.totalCount,
+					);
+				}
+				if (diff.totalCount === 1) return this.localize.term('uSync_diffOneChange');
+				return this.localize.term('uSync_diffChangeCount', diff.totalCount);
+			}
+			case 'lines': {
+				const { added, removed } = this.#lineCounts();
+				return this.localize.term('uSync_diffLineCount', added, removed);
+			}
+			case 'masked':
+				return this.localize.term('uSync_diffMaskedShort');
+			case 'single':
+				return c.oldText === ''
+					? this.localize.term('uSync_diffValueAdded')
+					: this.localize.term('uSync_diffValueRemoved');
+			case 'oversized':
+				return this.localize.term('uSync_diffTooLargeShort');
+			case 'notice':
+				return c.oldText;
+			case 'words':
+				return this.localize.term('uSync_diffValueChanged');
+			case 'skip':
+			default:
+				return this.localize.term('uSync_noChange');
+		}
+	}
+
+	#renderBody(c: USyncClassifiedChange) {
+		switch (c.strategy) {
+			case 'json':
+				return this.#renderJsonBody(c);
+			case 'lines':
+				return this.#renderLinesBody();
+			case 'words':
+				return this.#renderWordsBody(c);
+			case 'single':
+				return this.#renderSingleBody(c);
+			case 'masked':
+				return this.#renderMaskedBody();
+			case 'oversized':
+				return this.#renderOversizedBody(c);
+			case 'notice':
+				return this.#renderNoticeBody(c);
+			default:
+				return nothing;
+		}
+	}
+
+	#renderJsonBody(c: USyncClassifiedChange) {
+		const diff = this._json;
+		if (!diff) return nothing;
+
+		return html`
+			<ul class="leaf-list">
+				${diff.changes.map((leaf, index) => this.#renderLeaf(leaf, index))}
+			</ul>
+			${when(
+				diff.truncated,
+				() =>
+					html`<p class="muted">
+						${this.localize.term(
+							diff.stopped ? 'uSync_diffMoreChangesAtLeast' : 'uSync_diffMoreChanges',
+							diff.totalCount - diff.changes.length,
+						)}
+					</p>`,
+			)}
+			${when(
+				diff.reordered.length > 0,
+				() =>
+					html`<p class="muted">
+						${this.localize.term('uSync_diffReordered')}: ${diff.reordered.join(', ')}
+					</p>`,
+			)}
+			${when(
+				this._showRaw,
+				() => html`
+					<div class="raw-values">
+						<div>
+							<div class="muted">${this.localize.term('uSync_diffOldValue')}</div>
+							<umb-code-block language="json" copy
+								>${prettyJson(c.oldJson)}</umb-code-block
+							>
+						</div>
+						<div>
+							<div class="muted">${this.localize.term('uSync_diffNewValue')}</div>
+							<umb-code-block language="json" copy
+								>${prettyJson(c.newJson)}</umb-code-block
+							>
+						</div>
+					</div>
+				`,
+			)}
+		`;
+	}
+
+	#renderLeaf(leaf: USyncLeafChange, index: number) {
+		const path = formatDiffPath(leaf.path);
+		const symbol = leaf.kind === 'added' ? '+' : leaf.kind === 'removed' ? '−' : '~';
+
+		return html`
+			<li class=${classMap({ leaf: true, [leaf.kind]: true })}>
+				<div class="leaf-path" title=${leaf.path}>
+					<span class="symbol">${symbol}</span>${path}
+					${when(
+						leaf.expanded,
+						() =>
+							html`<uui-tag
+								size="s"
+								look="secondary"
+								title=${this.localize.term('uSync_diffExpandedNote')}
+								>»</uui-tag
+							>`,
+					)}
+				</div>
+				<div class="leaf-value">${this.#renderLeafValue(leaf, index)}</div>
+			</li>
+		`;
+	}
+
+	#renderLeafValue(leaf: USyncLeafChange, index: number) {
+		if (leaf.kind === 'added') {
+			return html`<span class="added-value">${formatLeafValue(leaf.newValue)}</span>`;
+		}
+		if (leaf.kind === 'removed') {
+			return html`<span class="removed-value">${formatLeafValue(leaf.oldValue)}</span>`;
+		}
+
+		const oldText = formatLeafValue(leaf.oldValue);
+		const newText = formatLeafValue(leaf.newValue);
+		const bothSingleLine = !oldText.includes('\n') && !newText.includes('\n');
+		const combinedLen = oldText.length + newText.length;
+
+		if (bothSingleLine && combinedLen <= USYNC_DIFF_LIMITS.inlineScalarChars) {
+			return html`<span class="inline-change"
+				><del>${oldText}</del> → <ins>${newText}</ins></span
+			>`;
+		}
+
+		const bothStrings =
+			typeof leaf.oldValue === 'string' && typeof leaf.newValue === 'string';
+		const hasWhitespace = /\s/.test(oldText) || /\s/.test(newText);
+
+		if (
+			bothStrings &&
+			hasWhitespace &&
+			combinedLen <= USYNC_DIFF_LIMITS.maxScalarWordDiffBytes
+		) {
+			const words = diffWords(oldText, newText);
+			return html`<span class="word-diff"
+				>${words.map((word: UmbDiffChange) =>
+					word.added
+						? html`<ins>${word.value}</ins>`
+						: word.removed
+							? html`<del>${word.value}</del>`
+							: html`<span>${word.value}</span>`,
+				)}</span
+			>`;
+		}
+
+		const expanded = this._expandedLeaves.has(index);
+		return html`
+			<uui-button look="text" compact @click=${() => this.#toggleLeaf(index)}>
+				${expanded
+					? this.localize.term('uSync_diffHideRaw')
+					: this.localize.term('uSync_diffShowRaw')}
+			</uui-button>
+			${when(
+				expanded,
+				() => html`
+					<pre class="stacked"><del>- ${oldText}</del>
+<ins>+ ${newText}</ins></pre>
+				`,
+			)}
+		`;
+	}
+
+	#renderLinesBody() {
+		const blocks = this._lines ?? [];
+
+		return html`
+			${when(
+				this._lineDegraded,
+				() => html`<p class="muted">${this.localize.term('uSync_diffDegraded')}</p>`,
+			)}
+			<uui-scroll-container class="line-diff">
+				${blocks.map((block, index) =>
+					block.type === 'row'
+						? this.#renderLineRow(block.row)
+						: this.#renderCollapsed(block, index),
+				)}
+			</uui-scroll-container>
+		`;
+	}
+
+	#renderLineRow(row: USyncLineDiffRow) {
+		const tint =
+			row.type === 'add'
+				? 'color-mix(in srgb, var(--uui-color-positive) 12%, transparent)'
+				: row.type === 'remove'
+					? 'color-mix(in srgb, var(--uui-color-danger) 12%, transparent)'
+					: undefined;
+		const marker = row.type === 'add' ? '+' : row.type === 'remove' ? '-' : ' ';
+
+		return html`
+			<div
+				class="line-row ${row.type}"
+				style=${styleMap({ background: tint ?? 'transparent' })}>
+				<span class="gutter">${row.oldLine ?? ''}</span>
+				<span class="gutter">${row.newLine ?? ''}</span>
+				<span class="marker">${marker}</span>
+				<span class="text">${row.text}</span>
+			</div>
+		`;
+	}
+
+	#renderCollapsed(
+		block: Extract<USyncLineDiffBlock, { type: 'collapsed' }>,
+		index: number,
+	) {
+		const expanded = this._expandedRuns.has(index);
+
+		return html`
+			<div class="collapsed-toggle" @click=${() => this.#toggleRun(index)}>
+				<uui-icon name="icon-navigation"></uui-icon>
+				${expanded
+					? this.localize.term('uSync_diffHideUnchanged')
+					: this.localize.term('uSync_diffShowUnchanged', block.count)}
+			</div>
+			${when(expanded, () => html`${block.rows.map((row) => this.#renderLineRow(row))}`)}
+		`;
+	}
+
+	#renderWordsBody(c: USyncClassifiedChange) {
+		const changes = diffWords(c.oldText, c.newText);
+		return html`<pre class="word-diff">
+${changes.map((word: UmbDiffChange) =>
+				word.added
+					? html`<ins>${word.value}</ins>`
+					: word.removed
+						? html`<del>${word.value}</del>`
+						: html`<span>${word.value}</span>`,
+			)}</pre
+		>`;
+	}
+
+	#renderSingleBody(c: USyncClassifiedChange) {
+		const isAdded = c.oldText === '';
+		const value = isAdded ? c.newText : c.oldText;
+		const tint = isAdded
+			? 'color-mix(in srgb, var(--uui-color-positive) 12%, transparent)'
+			: 'color-mix(in srgb, var(--uui-color-danger) 12%, transparent)';
+
+		return html`
+			<div class="muted">
+				${isAdded
+					? this.localize.term('uSync_diffValueAdded')
+					: this.localize.term('uSync_diffValueRemoved')}
+			</div>
+			<div class="tinted" style=${styleMap({ background: tint })}>
+				<umb-code-block language=${c.language} copy>${value}</umb-code-block>
+			</div>
+		`;
+	}
+
+	#renderMaskedBody() {
+		return html`<p class="muted">${this.localize.term('uSync_diffMasked')}</p>`;
+	}
+
+	#renderOversizedBody(c: USyncClassifiedChange) {
+		return html`
+			<p class="muted">${this.localize.term('uSync_diffTooLarge')}</p>
+			<div class="raw-values">
+				<div>
+					<div class="muted">${this.localize.term('uSync_diffOldValue')}</div>
+					<umb-code-block language=${c.language} copy>${c.oldText}</umb-code-block>
+				</div>
+				<div>
+					<div class="muted">${this.localize.term('uSync_diffNewValue')}</div>
+					<umb-code-block language=${c.language} copy>${c.newText}</umb-code-block>
+				</div>
+			</div>
+		`;
+	}
+
+	#renderNoticeBody(c: USyncClassifiedChange) {
+		const label =
+			this.detail?.change === ChangeDetailType.ERROR
+				? this.localize.term('uSync_changeError')
+				: this.localize.term('uSync_changeWarning');
+
+		return html`
+			<div class="notice-callout danger">
+				<strong>${label}</strong>
+				<p>${c.oldText}</p>
+			</div>
+		`;
+	}
+
+	static styles = css`
+		:host {
+			display: block;
+			border-bottom: 1px solid var(--uui-color-border);
+		}
+
+		.change-row.danger {
+			border-left: 3px solid var(--uui-color-danger);
+		}
+
+		.summary {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: var(--uui-size-space-4);
+			padding: var(--uui-size-space-3) var(--uui-size-space-5);
+			cursor: pointer;
+		}
+
+		.summary.static {
+			cursor: default;
+		}
+
+		.summary:hover:not(.static) {
+			background-color: var(--uui-color-surface-alt);
+		}
+
+		.summary-left {
+			display: flex;
+			align-items: center;
+			gap: var(--uui-size-space-3);
+			min-width: 0;
+			overflow: hidden;
+		}
+
+		.summary-left .label {
+			font-weight: bold;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		.prefix {
+			color: var(--uui-color-disabled-contrast);
+		}
+
+		.summary-right {
+			display: flex;
+			align-items: center;
+			gap: var(--uui-size-space-4);
+			flex-shrink: 0;
+		}
+
+		.summary-right uui-icon {
+			transition: transform 90ms ease;
+		}
+
+		.summary-right uui-icon.expanded {
+			transform: rotate(90deg);
+		}
+
+		.danger {
+			color: var(--uui-color-danger);
+		}
+
+		.color-red {
+			color: var(--uui-color-danger);
+		}
+
+		.muted {
+			color: var(--uui-color-disabled-contrast);
+			font-size: smaller;
+		}
+
+		.body {
+			padding: 0 var(--uui-size-space-5) var(--uui-size-space-4);
+		}
+
+		.path-line {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: var(--uui-size-space-3);
+			margin-top: var(--uui-size-space-3);
+		}
+
+		.path-line > .muted {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		.path-line-actions {
+			display: flex;
+			align-items: center;
+			gap: var(--uui-size-space-1, 3px);
+			flex-shrink: 0;
+		}
+
+		.leaf-list {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+			display: flex;
+			flex-direction: column;
+			gap: var(--uui-size-space-3);
+		}
+
+		.leaf {
+			display: flex;
+			flex-direction: column;
+			gap: var(--uui-size-space-1, 3px);
+			padding: var(--uui-size-space-2) var(--uui-size-space-3);
+			border-radius: var(--uui-border-radius);
+			border: 1px solid var(--uui-color-border);
+			background: var(--uui-color-surface-alt);
+		}
+
+		.leaf.added {
+			background: color-mix(in srgb, var(--uui-color-positive) 8%, transparent);
+			border-color: color-mix(in srgb, var(--uui-color-positive) 30%, transparent);
+		}
+
+		.leaf.removed {
+			background: color-mix(in srgb, var(--uui-color-danger) 8%, transparent);
+			border-color: color-mix(in srgb, var(--uui-color-danger) 30%, transparent);
+		}
+
+		.leaf-path {
+			font-family: monospace;
+			font-size: smaller;
+			font-weight: 600;
+			color: var(--uui-color-text);
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		.symbol {
+			display: inline-block;
+			width: 1em;
+			font-weight: bold;
+		}
+
+		.added-value {
+			color: var(--uui-color-positive);
+		}
+
+		.removed-value {
+			color: var(--uui-color-danger);
+		}
+
+		.inline-change del {
+			color: var(--uui-color-danger);
+			text-decoration: line-through;
+		}
+
+		.inline-change ins {
+			color: var(--uui-color-positive);
+			text-decoration: none;
+		}
+
+		.word-diff {
+			white-space: pre-wrap;
+		}
+
+		.word-diff ins {
+			color: var(--uui-color-positive);
+			text-decoration: none;
+		}
+
+		.word-diff del {
+			color: var(--uui-color-danger);
+			text-decoration: line-through;
+		}
+
+		.stacked {
+			margin: 0;
+			white-space: pre;
+		}
+
+		.stacked del {
+			display: block;
+			color: var(--uui-color-danger);
+			text-decoration: none;
+		}
+
+		.stacked ins {
+			display: block;
+			color: var(--uui-color-positive);
+			text-decoration: none;
+		}
+
+		.raw-values {
+			display: flex;
+			flex-direction: column;
+			gap: var(--uui-size-space-4);
+			margin-top: var(--uui-size-space-3);
+		}
+
+		.tinted {
+			border-radius: var(--uui-border-radius);
+		}
+
+		uui-scroll-container.line-diff {
+			max-height: 400px;
+			display: block;
+			border: 1px solid var(--uui-color-border);
+			border-radius: var(--uui-border-radius);
+		}
+
+		.line-row {
+			display: flex;
+			gap: var(--uui-size-space-2);
+			font-family: monospace;
+			white-space: pre;
+			padding: 0 var(--uui-size-space-2);
+		}
+
+		.line-row .gutter {
+			display: inline-block;
+			width: 3em;
+			text-align: right;
+			color: var(--uui-color-disabled-contrast);
+			flex-shrink: 0;
+		}
+
+		.line-row .marker {
+			flex-shrink: 0;
+			width: 1em;
+		}
+
+		.line-row .text {
+			white-space: pre;
+		}
+
+		.collapsed-toggle {
+			display: flex;
+			align-items: center;
+			gap: var(--uui-size-space-2);
+			padding: var(--uui-size-space-2);
+			color: var(--uui-color-disabled-contrast);
+			cursor: pointer;
+			font-size: smaller;
+		}
+
+		.collapsed-toggle:hover {
+			background-color: var(--uui-color-surface-alt);
+		}
+
+		.notice-callout {
+			padding: var(--uui-size-space-4);
+			border-radius: var(--uui-border-radius);
+			background: color-mix(in srgb, var(--uui-color-danger) 10%, transparent);
+		}
+
+		.notice-callout p {
+			margin: var(--uui-size-space-2) 0 0;
+		}
+	`;
+}
+
+export default uSyncChangeDetail;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'usync-change-detail': uSyncChangeDetail;
+	}
+}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-change-view.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-change-view.ts
@@ -1,51 +1,68 @@
-import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import {
-	LitElement,
 	classMap,
 	css,
 	customElement,
 	html,
 	property,
+	repeat,
 } from '@umbraco-cms/backoffice/external/lit';
-import { ChangeType, USyncActionView } from '@jumoo/uSync';
-import { diffWords } from '@umbraco-cms/backoffice/utils';
+import {
+	ChangeDetailType,
+	ChangeType,
+	type USyncActionView,
+	type USyncChange,
+} from '@jumoo/uSync';
+import './usync-change-detail.js';
 
 /**
  * shows the change details for an item.
  */
 @customElement('usync-change-view')
-export class uSyncChangeView extends UmbElementMixin(LitElement) {
+export class uSyncChangeView extends UmbLitElement {
 	@property({ type: Object })
 	item?: USyncActionView;
 
+	#renderable() {
+		return (this.item?.details ?? []).filter(
+			(detail) => detail.change !== ChangeDetailType.NO_CHANGE,
+		);
+	}
+
 	render() {
-		if (this.item?.change == ChangeType.CREATE) {
+		if (this.item?.change === ChangeType.CREATE) {
 			return this.render_create();
 		}
 
-		if (this.item?.details.length ?? 0 > 0) {
-			return this.renderChangeTable();
+		// note: this has to test the *renderable* details, not the raw count -
+		// an unchanged item still arrives with a single `NoChange` detail, and
+		// branching on the raw length would render an empty list instead of
+		// the "no changes" message.
+		const details = this.#renderable();
+		if (details.length > 0) {
+			return this.renderDetails(details);
 		} else {
 			return this.renderNoChanges();
 		}
 	}
 
-	renderChangeTable() {
+	renderDetails(details: Array<USyncChange>) {
+		// with a single change there's nothing to scan past, so open it
+		// straight away; with more than one, start collapsed and let the user
+		// open the ones they care about.
+		const startOpen = details.length <= 1;
+
 		return html`
-			<uui-table>
-				<uui-table-head>
-					<uui-table-head-cell>
-						<umb-localize key="uSync_changeAction">Action</umb-localize>
-					</uui-table-head-cell>
-					<uui-table-head-cell>
-						<umb-localize key="uSync_changeItem">Item</umb-localize>
-					</uui-table-head-cell>
-					<uui-table-head-cell>
-						<umb-localize key="uSync_changeDiffrence">Difference</umb-localize>
-					</uui-table-head-cell>
-				</uui-table-head>
-				${this.render_details()}
-			</uui-table>
+			<div class="detail-list">
+				${repeat(
+					details,
+					(detail, index) => `${index}:${detail.path}:${detail.name}`,
+					(detail) =>
+						html`<usync-change-detail
+							.detail=${detail}
+							?open=${startOpen}></usync-change-detail>`,
+				)}
+			</div>
 		`;
 	}
 
@@ -74,7 +91,7 @@ export class uSyncChangeView extends UmbElementMixin(LitElement) {
 
 	renderMessage() {
 		const message =
-			(this.item?.message?.length ?? 0 > 0)
+			(this.item?.message?.length ?? 0) > 0
 				? this.item?.message
 				: this.item?.change == ChangeType.IMPORT
 					? 'No changes were made but the item was imported'
@@ -84,50 +101,10 @@ export class uSyncChangeView extends UmbElementMixin(LitElement) {
 		return html`<div class="${classMap(classes)}">${message}</div> `;
 	}
 
-	#getJsonOrString(value: string | null | undefined) {
-		try {
-			return JSON.stringify(JSON.parse(value ?? ''), null, 1);
-		} catch {
-			return value ?? '';
-		}
-	}
-
-	render_details() {
-		var changesHtml = this.item?.details.map((detail) => {
-			const oldValue = this.#getJsonOrString(detail.oldValue);
-			const newValue = this.#getJsonOrString(detail.newValue);
-			const changes = diffWords(oldValue, newValue);
-
-			const changeHtml = changes.map((change: any) => {
-				if (change.added) {
-					return html`<ins>${change.value}</ins>`;
-				} else if (change.removed) {
-					return html`<del>${change.value}</del>`;
-				} else {
-					return html`<span>${change.value}</span>`;
-				}
-			});
-
-			return html`
-				<uui-table-row>
-					<uui-table-cell>${detail.name}</uui-table-cell>
-					<uui-table-cell>${detail.change}</uui-table-cell>
-					<uui-table-cell class="detail-data">
-						<pre>${changeHtml}</pre>
-					</uui-table-cell>
-				</uui-table-row>
-			`;
-		});
-
-		return changesHtml;
-	}
-
-	render_changes() {}
-
 	static styles = css`
 		:host {
 			display: block;
-			margin: var(--uui-size-space-4) 0;
+			margin: 0;
 		}
 
 		.change-box {
@@ -147,23 +124,18 @@ export class uSyncChangeView extends UmbElementMixin(LitElement) {
 			margin-top: var(--uui-size-space-2);
 		}
 
-		uui-table-cell {
-			vertical-align: top;
-		}
-
-		uui-table-cell pre {
-			margin: 0;
-			padding: 0;
-		}
-
-		pre ins {
-			color: var(--uui-color-positive);
-		}
-
-		pre del {
-			color: var(--uui-color-danger);
+		.detail-list {
+			display: flex;
+			flex-direction: column;
+			border-top: 1px solid var(--uui-color-border);
 		}
 	`;
 }
 
 export default uSyncChangeView;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'usync-change-view': uSyncChangeView;
+	}
+}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/en-us.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/en-us.ts
@@ -45,6 +45,45 @@ export default {
 		changeAction: 'Action',
 		changeItem: 'Item',
 		changeDiffrence: 'Difference',
+
+		changeProperty: 'Property',
+		changeRawXml: 'Raw XML',
+		changeError: 'Error',
+		changeWarning: 'Warning',
+
+		diffOneChange: '1 change',
+		diffChangeCount: '{0} changes',
+		diffChangeCapped: '{0} of {1} changes',
+		diffMoreChanges: '+{0} more changes',
+		diffMoreChangesAtLeast: '+{0} or more changes',
+		diffLineCount: '+{0} / -{1} lines',
+		diffShowUnchanged: 'Show {0} unchanged lines',
+		diffHideUnchanged: 'Hide unchanged lines',
+
+		diffValueChanged: 'Value changed',
+		diffValueAdded: 'Value added',
+		diffValueRemoved: 'Value removed',
+		diffReordered: 'Items reordered',
+
+		diffMaskedShort: 'Hidden value',
+		diffMasked: 'This value is hidden and cannot be compared',
+		diffTooLargeShort: 'Too large to compare',
+		diffTooLarge: 'This value is too large to compare, showing the raw values instead',
+		diffDegraded:
+			'This comparison was too large to fully calculate, so it has been simplified',
+
+		diffAdded: 'Added',
+		diffRemoved: 'Removed',
+		diffChanged: 'Changed',
+		diffOldValue: 'Old value',
+		diffNewValue: 'New value',
+
+		diffShowRaw: 'Show raw values',
+		diffHideRaw: 'Hide raw values',
+		diffPath: 'Path: {0}',
+		diffCopyPath: 'Copy path',
+		diffExpandedNote: 'This value contains encoded JSON, which has been expanded',
+
 		changeCreate: 'This item does not exist in Umbraco and is being created',
 		noChangesImport: 'No changes were made to this item',
 		noChangesReport: 'No changes detected',

--- a/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/change-name.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/change-name.ts
@@ -1,0 +1,45 @@
+export interface USyncChangeLabel {
+	label: string;
+	prefix?: string;
+	culture?: string;
+	raw: string;
+}
+
+// Tight language-tag pattern so a plain "(2)" (e.g. "Sort Order (2)") is never
+// mistaken for a culture - a culture must start with 2-3 letters.
+const CULTURE_SUFFIX = /^(.*?)\s*\(([A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)\)\s*$/;
+
+const PROPERTY_PREFIX = /^Property\s*-\s*/;
+
+/**
+ * Splits a `USyncChange.name` into a display label, an optional `Property -`
+ * prefix, and an optional trailing culture. When nothing matches, the name is
+ * left completely alone - other trackers produce arbitrary names and we must
+ * not mangle them.
+ */
+export function parseChangeName(name: string): USyncChangeLabel {
+	const cultureMatch = CULTURE_SUFFIX.exec(name);
+
+	let remaining = name;
+	let culture: string | undefined;
+
+	if (cultureMatch) {
+		remaining = cultureMatch[1];
+		culture = cultureMatch[2];
+	}
+
+	const prefixMatch = PROPERTY_PREFIX.exec(remaining);
+	let prefix: string | undefined;
+	let label = remaining;
+
+	if (prefixMatch) {
+		prefix = 'Property';
+		label = remaining.slice(prefixMatch[0].length);
+	}
+
+	if (!cultureMatch && !prefixMatch) {
+		return { label: name, raw: name };
+	}
+
+	return { label, prefix, culture, raw: name };
+}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/classify-change.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/classify-change.ts
@@ -1,0 +1,141 @@
+import type { USyncChange } from '../../api/types.gen.js';
+import { USYNC_DIFF_LIMITS, type USyncClassifiedChange } from './types.js';
+
+// `ChangeDetailType` is an enum, and importing it as a value is not permitted
+// here (only type-only imports from the generated API types are allowed) -
+// so its members are matched against their known string values instead.
+const CHANGE_NO_CHANGE = 'NoChange';
+const CHANGE_ERROR = 'Error';
+const CHANGE_WARNING = 'Warning';
+
+export const USYNC_MASKED_VALUE = '*****';
+
+const RAW_XML_DETAIL_NAME = 'Raw XML';
+
+export type USyncJsonContainerResult = { ok: true; value: unknown } | { ok: false };
+
+/**
+ * Parses `text` as a JSON *container* (object or array) only. Bare scalars
+ * such as `123` or `"hi"` parse successfully with `JSON.parse` but are never
+ * what we mean by "this is a JSON value to structurally diff" - a
+ * `textstring` of `123` must not be treated as JSON.
+ */
+export function tryParseJsonContainer(text: string): USyncJsonContainerResult {
+	const trimmed = text.trim();
+	if (!(trimmed.startsWith('{') || trimmed.startsWith('['))) return { ok: false };
+	try {
+		const value: unknown = JSON.parse(trimmed);
+		if (value === null || typeof value !== 'object') return { ok: false };
+		return { ok: true, value };
+	} catch {
+		return { ok: false };
+	}
+}
+
+function byteLength(text: string): number {
+	return new TextEncoder().encode(text).length;
+}
+
+const XML_START = /^\s*</;
+
+/**
+ * Classifies a `USyncChange` detail into a diff strategy, in priority order.
+ * See the plan for the full rationale behind the ordering.
+ */
+export function classifyChange(detail: USyncChange): USyncClassifiedChange {
+	const { oldValue, newValue, name } = detail;
+	const change: string = detail.change;
+
+	if (change === CHANGE_NO_CHANGE) {
+		return skip(oldValue, newValue);
+	}
+
+	if (change === CHANGE_ERROR) {
+		return notice(oldValue);
+	}
+
+	if (change === CHANGE_WARNING) {
+		return notice(newValue);
+	}
+
+	if (oldValue === USYNC_MASKED_VALUE || newValue === USYNC_MASKED_VALUE) {
+		return build('masked', oldValue, newValue, 'text');
+	}
+
+	const bytes = Math.max(byteLength(oldValue), byteLength(newValue));
+	const forceXml = name === RAW_XML_DETAIL_NAME;
+
+	if (bytes > USYNC_DIFF_LIMITS.maxDiffBytes) {
+		return build('oversized', oldValue, newValue, forceXml ? 'xml' : 'text', bytes);
+	}
+
+	if (oldValue === newValue) {
+		return skip(oldValue, newValue);
+	}
+
+	if (oldValue === '' || newValue === '') {
+		return build('single', oldValue, newValue, forceXml ? 'xml' : 'text', bytes);
+	}
+
+	const oldJson = tryParseJsonContainer(oldValue);
+	const newJson = tryParseJsonContainer(newValue);
+	if (oldJson.ok && newJson.ok) {
+		return {
+			strategy: 'json',
+			oldText: oldValue,
+			newText: newValue,
+			oldJson: oldJson.value,
+			newJson: newJson.value,
+			language: 'json',
+			bytes,
+		};
+	}
+
+	if (forceXml || XML_START.test(oldValue) || XML_START.test(newValue)) {
+		return build('lines', oldValue, newValue, 'xml', bytes);
+	}
+
+	if (oldValue.includes('\n') || newValue.includes('\n')) {
+		return build('lines', oldValue, newValue, 'text', bytes);
+	}
+
+	if (bytes <= USYNC_DIFF_LIMITS.inlineScalarChars) {
+		return build('scalar', oldValue, newValue, 'text', bytes);
+	}
+
+	if (bytes <= USYNC_DIFF_LIMITS.maxWordDiffBytes) {
+		return build('words', oldValue, newValue, 'text', bytes);
+	}
+
+	return build('lines', oldValue, newValue, 'text', bytes);
+}
+
+function skip(oldValue: string, newValue: string): USyncClassifiedChange {
+	return build('skip', oldValue, newValue, 'text');
+}
+
+function notice(message: string): USyncClassifiedChange {
+	return {
+		strategy: 'notice',
+		oldText: message,
+		newText: message,
+		language: 'text',
+		bytes: byteLength(message),
+	};
+}
+
+function build(
+	strategy: USyncClassifiedChange['strategy'],
+	oldValue: string,
+	newValue: string,
+	language: USyncClassifiedChange['language'],
+	bytes?: number,
+): USyncClassifiedChange {
+	return {
+		strategy,
+		oldText: oldValue,
+		newText: newValue,
+		language,
+		bytes: bytes ?? Math.max(byteLength(oldValue), byteLength(newValue)),
+	};
+}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/deep-equal.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/deep-equal.ts
@@ -1,0 +1,51 @@
+/**
+ * A short tag describing the "shape" of a value, used to decide whether two
+ * values are even comparable as the same kind of thing (object vs array vs
+ * primitive) before doing a structural walk.
+ */
+export function typeTag(value: unknown): string {
+	if (value === null) return 'null';
+	if (Array.isArray(value)) return 'array';
+	const t = typeof value;
+	if (t === 'object') return 'object';
+	return t;
+}
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (value === null || typeof value !== 'object') return false;
+	if (Array.isArray(value)) return false;
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Structural equality for JSON-shaped values (objects, arrays, strings,
+ * numbers, booleans, null). Array order is significant. Object key order is
+ * not.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+
+	if (Array.isArray(a) && Array.isArray(b)) {
+		if (a.length !== b.length) return false;
+		for (let i = 0; i < a.length; i++) {
+			if (!deepEqual(a[i], b[i])) return false;
+		}
+		return true;
+	}
+
+	if (isPlainObject(a) && isPlainObject(b)) {
+		const aKeys = Object.keys(a);
+		const bKeys = Object.keys(b);
+		if (aKeys.length !== bKeys.length) return false;
+		for (const key of aKeys) {
+			if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+			if (!deepEqual(a[key], b[key])) return false;
+		}
+		return true;
+	}
+
+	// Different shapes (one array one object, one object one primitive, etc.)
+	// or unequal primitives - already excluded by the `a === b` check above.
+	return false;
+}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/format-value.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/format-value.ts
@@ -1,0 +1,105 @@
+import { isPlainObject } from './deep-equal.js';
+
+const IDENTIFIER_KEY = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * Joins a path segment onto a base path, using `.key` for identifier-safe
+ * keys and `["odd key"]` otherwise.
+ */
+export function joinKey(base: string, key: string): string {
+	if (IDENTIFIER_KEY.test(key)) {
+		return base.length > 0 ? `${base}.${key}` : key;
+	}
+	return `${base}[${JSON.stringify(key)}]`;
+}
+
+const ELEMENT_LABEL_FIELDS = [
+	'name',
+	'alias',
+	'editorAlias',
+	'propertyAlias',
+	'contentTypeAlias',
+	'$type',
+	'culture',
+];
+
+function deriveElementLabel(element: unknown): string | undefined {
+	if (!isPlainObject(element)) return undefined;
+	for (const field of ELEMENT_LABEL_FIELDS) {
+		const value = element[field];
+		if (typeof value === 'string' && value.length > 0) return value;
+	}
+	return undefined;
+}
+
+export interface USyncElementPathOptions {
+	/** Positional index, used when no identity label is available. */
+	index?: number;
+	/**
+	 * A pre-built identity label (e.g. `headline (en-US)` for the
+	 * alias+culture composite identity) - when set this *is* the element's
+	 * identity, so no index/derived-label lookup happens.
+	 */
+	identityLabel?: string;
+}
+
+/**
+ * Builds a readable path segment for an array element, e.g. `[0: Hero]` for
+ * an index-matched element, or `[headline (en-US)]` for an element matched by
+ * a composite alias+culture identity.
+ */
+export function elementPath(
+	base: string,
+	element: unknown,
+	options: USyncElementPathOptions = {},
+): string {
+	if (options.identityLabel !== undefined) {
+		return `${base}[${options.identityLabel}]`;
+	}
+	const index = options.index ?? 0;
+	const label = deriveElementLabel(element);
+	return label !== undefined ? `${base}[${index}: ${label}]` : `${base}[${index}]`;
+}
+
+const LEAF_SEGMENT = /(\.[^.[\]]+|\[[^\]]*\])$/;
+
+/**
+ * Truncates a long path in the middle, keeping the trailing leaf segment
+ * (the part the reader actually cares about) fully intact.
+ */
+export function formatDiffPath(path: string, maxLen = 120): string {
+	if (path.length <= maxLen) return path;
+	const leafMatch = LEAF_SEGMENT.exec(path);
+	const leaf = leafMatch ? leafMatch[0] : '';
+	const headLen = Math.max(maxLen - leaf.length - 1, 0);
+	const head = path.slice(0, headLen);
+	return `${head}…${leaf}`;
+}
+
+/**
+ * Short, display-agnostic stringification of a leaf value for inline
+ * rendering (e.g. `old → new`). Callers decide layout/markup; this only
+ * turns a value into text.
+ */
+export function formatLeafValue(value: unknown): string {
+	if (value === undefined) return 'undefined';
+	if (value === null) return 'null';
+	if (typeof value === 'string') return value;
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+	return JSON.stringify(value);
+}
+
+/** Pretty-prints a parsed JSON value the same way the server does. */
+export function prettyJson(value: unknown): string {
+	return JSON.stringify(value, null, 1);
+}
+
+/** Truncates a string in the middle to roughly `maxLen` characters. */
+export function truncateMiddle(text: string, maxLen: number): string {
+	if (text.length <= maxLen) return text;
+	const ellipsis = '…';
+	const keep = Math.max(maxLen - ellipsis.length, 0);
+	const headLen = Math.ceil(keep / 2);
+	const tailLen = Math.floor(keep / 2);
+	return `${text.slice(0, headLen)}${ellipsis}${text.slice(text.length - tailLen)}`;
+}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/index.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/index.ts
@@ -1,0 +1,7 @@
+export * from './types.js';
+export * from './deep-equal.js';
+export * from './format-value.js';
+export * from './change-name.js';
+export * from './classify-change.js';
+export * from './json-diff.js';
+export * from './line-diff.js';

--- a/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/json-diff.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/json-diff.ts
@@ -1,0 +1,414 @@
+import { deepEqual, isPlainObject, typeTag } from './deep-equal.js';
+import { elementPath, joinKey } from './format-value.js';
+import { tryParseJsonContainer } from './classify-change.js';
+import {
+	USYNC_DIFF_LIMITS,
+	type USyncJsonDiffResult,
+	type USyncLeafChange,
+} from './types.js';
+
+// A private sentinel for "this side has no value at all" - distinct from
+// `undefined`, which can legitimately appear as the result of a string
+// expansion round-trip. This keeps `{"a": null}` vs `{}` distinguishable from
+// a missing key.
+const MISSING = Symbol('usync-diff-missing');
+type Missing = typeof MISSING;
+
+/**
+ * Composite identities are tried before single fields, and in the order
+ * listed - a block's `values` entries and property values key on
+ * alias(+culture/segment) almost always, and that composite survives
+ * serialisation round-trips even when raw GUIDs don't.
+ */
+export const USYNC_COMPOSITE_IDENTITIES: string[][] = [
+	['alias', 'culture', 'segment'], // block `values`, property values
+	['propertyAlias', 'culture', 'segment'],
+	['contentKey', 'culture', 'segment'],
+];
+
+// `$type` is deliberately excluded - it's a label, not an identity: it's
+// never unique within a block array.
+export const USYNC_IDENTITY_FIELDS: string[] = [
+	'key',
+	'udi',
+	'contentUdi',
+	'contentKey',
+	'settingsKey',
+	'id',
+	'alias',
+	'editorAlias',
+	'name',
+];
+
+interface IdentityStrategy {
+	isComposite: boolean;
+	keyOf(element: Record<string, unknown>): string;
+	labelOf(element: Record<string, unknown>): string;
+}
+
+function isUniqueAndIntersecting(
+	a: unknown[],
+	b: unknown[],
+	keyOf: (element: Record<string, unknown>) => string,
+): boolean {
+	const aKeys = a.map((element) => keyOf(element as Record<string, unknown>));
+	const bKeys = b.map((element) => keyOf(element as Record<string, unknown>));
+	if (new Set(aKeys).size !== aKeys.length) return false;
+	if (new Set(bKeys).size !== bKeys.length) return false;
+
+	// The load-bearing check: Umbraco regenerates block `key` GUIDs on some
+	// serialisation paths. If both sides have unique but entirely disjoint
+	// keys, identity matching would report "everything removed, everything
+	// added" - strictly worse than index matching. Requiring a shared key
+	// means we only key when the key actually carries continuity across the
+	// two sides; otherwise we correctly fall back to index matching.
+	const bSet = new Set(bKeys);
+	return aKeys.some((key) => bSet.has(key));
+}
+
+function tryCompositeStrategy(
+	fields: string[],
+	a: unknown[],
+	b: unknown[],
+): IdentityStrategy | null {
+	const primary = fields[0];
+	const hasPrimary = (elements: unknown[]) =>
+		elements.every((element) => {
+			if (!isPlainObject(element)) return false;
+			const value = element[primary];
+			return typeof value === 'string' && value.length > 0;
+		});
+	if (!hasPrimary(a) || !hasPrimary(b)) return null;
+
+	const keyOf = (element: Record<string, unknown>) =>
+		fields
+			.map((field) =>
+				typeof element[field] === 'string' ? (element[field] as string) : '',
+			)
+			.join('\u0000');
+
+	const labelOf = (element: Record<string, unknown>) => {
+		const primaryValue = String(element[primary]);
+		const culture = fields.includes('culture') ? element.culture : undefined;
+		return typeof culture === 'string' && culture.length > 0
+			? `${primaryValue} (${culture})`
+			: primaryValue;
+	};
+
+	if (!isUniqueAndIntersecting(a, b, keyOf)) return null;
+	return { isComposite: true, keyOf, labelOf };
+}
+
+function trySingleFieldStrategy(
+	field: string,
+	a: unknown[],
+	b: unknown[],
+): IdentityStrategy | null {
+	const hasField = (elements: unknown[]) =>
+		elements.every((element) => {
+			if (!isPlainObject(element)) return false;
+			const value = element[field];
+			return typeof value === 'string' || typeof value === 'number';
+		});
+	if (!hasField(a) || !hasField(b)) return null;
+
+	const keyOf = (element: Record<string, unknown>) => String(element[field]);
+	const labelOf = (element: Record<string, unknown>) => String(element[field]);
+
+	if (!isUniqueAndIntersecting(a, b, keyOf)) return null;
+	return { isComposite: false, keyOf, labelOf };
+}
+
+/**
+ * Picks an identity strategy for matching elements of two arrays by identity
+ * rather than position, or `null` when neither array offers one (the caller
+ * should fall back to index matching).
+ */
+export function pickIdentity(a: unknown[], b: unknown[]): IdentityStrategy | null {
+	if (a.length === 0 || b.length === 0) return null;
+	if (!a.every(isPlainObject) || !b.every(isPlainObject)) return null;
+
+	for (const fields of USYNC_COMPOSITE_IDENTITIES) {
+		const strategy = tryCompositeStrategy(fields, a, b);
+		if (strategy) return strategy;
+	}
+	for (const field of USYNC_IDENTITY_FIELDS) {
+		const strategy = trySingleFieldStrategy(field, a, b);
+		if (strategy) return strategy;
+	}
+	return null;
+}
+
+interface WalkContext {
+	changes: USyncLeafChange[];
+	totalCount: number;
+	reordered: string[];
+	maxChanges: number;
+	maxDepth: number;
+	expandJsonStrings: boolean;
+	maxStringExpansions: number;
+	stopped: boolean;
+}
+
+function record(
+	ctx: WalkContext,
+	expansions: number,
+	entry: Omit<USyncLeafChange, 'expanded'>,
+): void {
+	ctx.totalCount++;
+	if (ctx.changes.length < ctx.maxChanges) {
+		// Any leaf recorded while inside an expanded encoded-JSON string
+		// carries `expanded: true`, not just the leaf that triggered the
+		// expansion - it's the whole subtree that crossed into a string.
+		ctx.changes.push(expansions > 0 ? { ...entry, expanded: true } : entry);
+	}
+	// Hard-stop: don't keep walking a wholesale change (e.g. a 5000-element
+	// array rewrite) just to increment a counter past a few times the cap.
+	if (ctx.totalCount > ctx.maxChanges * 4) {
+		ctx.stopped = true;
+	}
+}
+
+function identityChildPath(
+	path: string,
+	strategy: IdentityStrategy,
+	element: Record<string, unknown>,
+	index: number,
+): string {
+	return strategy.isComposite
+		? elementPath(path, element, { identityLabel: strategy.labelOf(element) })
+		: elementPath(path, element, { index });
+}
+
+function walk(
+	ctx: WalkContext,
+	path: string,
+	a: unknown | Missing,
+	b: unknown | Missing,
+	depth: number,
+	expansions: number,
+): void {
+	if (ctx.stopped) return;
+
+	if (a === MISSING) {
+		record(ctx, expansions, { path, kind: 'added', newValue: b });
+		return;
+	}
+	if (b === MISSING) {
+		record(ctx, expansions, { path, kind: 'removed', oldValue: a });
+		return;
+	}
+	if (deepEqual(a, b)) return;
+
+	if (depth >= ctx.maxDepth) {
+		record(ctx, expansions, { path, kind: 'changed', oldValue: a, newValue: b });
+		return;
+	}
+
+	if (typeof a === 'string' && typeof b === 'string') {
+		if (ctx.expandJsonStrings && expansions < ctx.maxStringExpansions) {
+			const ea = tryParseJsonContainer(a);
+			const eb = tryParseJsonContainer(b);
+			// Only expand when BOTH sides parse - expanding one side only
+			// would compare a JSON structure against a raw string.
+			if (ea.ok && eb.ok) {
+				walk(ctx, `${path} » `, ea.value, eb.value, depth + 1, expansions + 1);
+				return;
+			}
+		}
+		record(ctx, expansions, { path, kind: 'changed', oldValue: a, newValue: b });
+		return;
+	}
+
+	if (typeTag(a) !== typeTag(b)) {
+		record(ctx, expansions, { path, kind: 'changed', oldValue: a, newValue: b });
+		return;
+	}
+
+	if (Array.isArray(a) && Array.isArray(b)) {
+		walkArray(ctx, path, a, b, depth, expansions);
+		return;
+	}
+
+	if (isPlainObject(a) && isPlainObject(b)) {
+		walkObject(ctx, path, a, b, depth, expansions);
+		return;
+	}
+
+	record(ctx, expansions, { path, kind: 'changed', oldValue: a, newValue: b });
+}
+
+function walkObject(
+	ctx: WalkContext,
+	path: string,
+	a: Record<string, unknown>,
+	b: Record<string, unknown>,
+	depth: number,
+	expansions: number,
+): void {
+	for (const key of Object.keys(a)) {
+		if (ctx.stopped) return;
+		const childPath = joinKey(path, key);
+		const bHasKey = Object.prototype.hasOwnProperty.call(b, key);
+		walk(ctx, childPath, a[key], bHasKey ? b[key] : MISSING, depth + 1, expansions);
+	}
+	for (const key of Object.keys(b)) {
+		if (ctx.stopped) return;
+		if (Object.prototype.hasOwnProperty.call(a, key)) continue;
+		walk(ctx, joinKey(path, key), MISSING, b[key], depth + 1, expansions);
+	}
+}
+
+function sameMultiset(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) return false;
+	const sorted = (arr: string[]) => [...arr].sort();
+	const sa = sorted(a);
+	const sb = sorted(b);
+	return sa.every((key, i) => key === sb[i]);
+}
+
+function sameOrder(a: string[], b: string[]): boolean {
+	return a.length === b.length && a.every((key, i) => key === b[i]);
+}
+
+function walkArray(
+	ctx: WalkContext,
+	path: string,
+	a: unknown[],
+	b: unknown[],
+	depth: number,
+	expansions: number,
+): void {
+	const strategy = pickIdentity(a, b);
+	if (!strategy) {
+		walkArrayByIndex(ctx, path, a, b, depth, expansions);
+		return;
+	}
+
+	const aEntries = a.map((element, index) => ({
+		element: element as Record<string, unknown>,
+		index,
+		key: strategy.keyOf(element as Record<string, unknown>),
+	}));
+	const bEntries = b.map((element, index) => ({
+		element: element as Record<string, unknown>,
+		index,
+		key: strategy.keyOf(element as Record<string, unknown>),
+	}));
+	const bByKey = new Map(bEntries.map((entry) => [entry.key, entry]));
+	const aByKey = new Map(aEntries.map((entry) => [entry.key, entry]));
+
+	for (const aEntry of aEntries) {
+		if (ctx.stopped) return;
+		const bEntry = bByKey.get(aEntry.key);
+		if (!bEntry) {
+			record(ctx, expansions, {
+				path: identityChildPath(path, strategy, aEntry.element, aEntry.index),
+				kind: 'removed',
+				oldValue: aEntry.element,
+			});
+			continue;
+		}
+		walk(
+			ctx,
+			identityChildPath(path, strategy, bEntry.element, bEntry.index),
+			aEntry.element,
+			bEntry.element,
+			depth + 1,
+			expansions,
+		);
+	}
+	for (const bEntry of bEntries) {
+		if (ctx.stopped) return;
+		if (!aByKey.has(bEntry.key)) {
+			record(ctx, expansions, {
+				path: identityChildPath(path, strategy, bEntry.element, bEntry.index),
+				kind: 'added',
+				newValue: bEntry.element,
+			});
+		}
+	}
+
+	const aKeys = aEntries.map((entry) => entry.key);
+	const bKeys = bEntries.map((entry) => entry.key);
+	if (sameMultiset(aKeys, bKeys) && !sameOrder(aKeys, bKeys)) {
+		ctx.reordered.push(path.length > 0 ? path : '(root)');
+	}
+}
+
+function walkArrayByIndex(
+	ctx: WalkContext,
+	path: string,
+	a: unknown[],
+	b: unknown[],
+	depth: number,
+	expansions: number,
+): void {
+	const minLen = Math.min(a.length, b.length);
+
+	let start = 0;
+	while (start < minLen && deepEqual(a[start], b[start])) start++;
+
+	let end = 0;
+	while (
+		end < minLen - start &&
+		deepEqual(a[a.length - 1 - end], b[b.length - 1 - end])
+	) {
+		end++;
+	}
+
+	const aMid = a.slice(start, a.length - end);
+	const bMid = b.slice(start, b.length - end);
+	const midLen = Math.max(aMid.length, bMid.length);
+
+	for (let i = 0; i < midLen; i++) {
+		if (ctx.stopped) return;
+		const aEl: unknown | Missing = i < aMid.length ? aMid[i] : MISSING;
+		const bEl: unknown | Missing = i < bMid.length ? bMid[i] : MISSING;
+		const index = start + i;
+		const sample = aEl !== MISSING ? aEl : bEl;
+		const childPath = elementPath(path, sample, { index });
+		walk(ctx, childPath, aEl, bEl, depth + 1, expansions);
+	}
+}
+
+export interface USyncJsonDiffOptions {
+	maxChanges?: number;
+	maxDepth?: number;
+	expandJsonStrings?: boolean;
+	maxStringExpansions?: number;
+}
+
+/**
+ * Structurally diffs two parsed JSON values, producing a flat list of leaf
+ * changes with readable paths instead of a wholesale before/after dump.
+ * Arrays are matched by identity where possible (see `pickIdentity`) so that
+ * inserting one block does not make every other block look changed.
+ */
+export function diffJsonValues(
+	oldValue: unknown,
+	newValue: unknown,
+	options?: USyncJsonDiffOptions,
+): USyncJsonDiffResult {
+	const ctx: WalkContext = {
+		changes: [],
+		totalCount: 0,
+		reordered: [],
+		maxChanges: options?.maxChanges ?? USYNC_DIFF_LIMITS.maxLeafChanges,
+		maxDepth: options?.maxDepth ?? USYNC_DIFF_LIMITS.maxJsonDepth,
+		expandJsonStrings: options?.expandJsonStrings ?? true,
+		maxStringExpansions:
+			options?.maxStringExpansions ?? USYNC_DIFF_LIMITS.maxStringExpansions,
+		stopped: false,
+	};
+
+	walk(ctx, '', oldValue, newValue, 0, 0);
+
+	return {
+		changes: ctx.changes,
+		totalCount: ctx.totalCount,
+		truncated: ctx.totalCount > ctx.changes.length,
+		stopped: ctx.stopped,
+		reordered: ctx.reordered,
+	};
+}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/line-diff.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/line-diff.ts
@@ -1,0 +1,266 @@
+import {
+	USYNC_DIFF_LIMITS,
+	type USyncLineDiffBlock,
+	type USyncLineDiffResult,
+	type USyncLineDiffRow,
+} from './types.js';
+
+function normalize(text: string): string {
+	return text.replace(/\r\n/g, '\n');
+}
+
+function contextRow(oldLine: number, newLine: number, text: string): USyncLineDiffRow {
+	return { type: 'context', oldLine, newLine, text };
+}
+
+function removeRow(oldLine: number, text: string): USyncLineDiffRow {
+	return { type: 'remove', oldLine, text };
+}
+
+function addRow(newLine: number, text: string): USyncLineDiffRow {
+	return { type: 'add', newLine, text };
+}
+
+/**
+ * Emits the whole [oldStart, oldEnd) / [newStart, newEnd) middle range as a
+ * wholesale remove-then-add - used both when the pathological-size guard
+ * trips and as the degrade path if Myers' `d` bound is hit.
+ */
+function wholesaleRows(
+	oldLines: string[],
+	newLines: string[],
+	oldStart: number,
+	oldEnd: number,
+	newStart: number,
+	newEnd: number,
+): USyncLineDiffRow[] {
+	const rows: USyncLineDiffRow[] = [];
+	for (let i = oldStart; i < oldEnd; i++) rows.push(removeRow(i + 1, oldLines[i]));
+	for (let i = newStart; i < newEnd; i++) rows.push(addRow(i + 1, newLines[i]));
+	return rows;
+}
+
+const MAX_D = 2000;
+
+/**
+ * Myers greedy forward diff (the classic O(ND) algorithm) over the given
+ * line ranges. Returns `null` if the edit distance exceeds `MAX_D`, in which
+ * case the caller should degrade to a wholesale remove/add instead of
+ * continuing to search.
+ */
+function myersDiff(
+	oldLines: string[],
+	newLines: string[],
+	oldStart: number,
+	oldEnd: number,
+	newStart: number,
+	newEnd: number,
+): USyncLineDiffRow[] | null {
+	const n = oldEnd - oldStart;
+	const m = newEnd - newStart;
+	const max = Math.min(n + m, MAX_D);
+
+	if (n === 0 && m === 0) return [];
+
+	const offset = max;
+	const v = new Int32Array(2 * max + 1);
+	const trace: Int32Array[] = [];
+
+	let found = false;
+	let foundD = -1;
+
+	for (let d = 0; d <= max; d++) {
+		const snapshot = v.slice();
+		trace.push(snapshot);
+
+		for (let k = -d; k <= d; k += 2) {
+			let x: number;
+			if (k === -d || (k !== d && v[k - 1 + offset] < v[k + 1 + offset])) {
+				x = v[k + 1 + offset];
+			} else {
+				x = v[k - 1 + offset] + 1;
+			}
+			let y = x - k;
+
+			while (x < n && y < m && oldLines[oldStart + x] === newLines[newStart + y]) {
+				x++;
+				y++;
+			}
+
+			v[k + offset] = x;
+
+			if (x >= n && y >= m) {
+				found = true;
+				foundD = d;
+				break;
+			}
+		}
+		if (found) break;
+	}
+
+	if (!found) return null;
+
+	// Backtrack through the trace to recover the edit script.
+	const rows: USyncLineDiffRow[] = [];
+	let x = n;
+	let y = m;
+
+	for (let d = foundD; d > 0; d--) {
+		const vPrev = trace[d];
+		const k = x - y;
+
+		let prevK: number;
+		if (k === -d || (k !== d && vPrev[k - 1 + offset] < vPrev[k + 1 + offset])) {
+			prevK = k + 1;
+		} else {
+			prevK = k - 1;
+		}
+		const prevX = vPrev[prevK + offset];
+		const prevY = prevX - prevK;
+
+		while (x > prevX && y > prevY) {
+			rows.push(contextRow(oldStart + x, newStart + y, oldLines[oldStart + x - 1]));
+			x--;
+			y--;
+		}
+
+		if (x === prevX) {
+			rows.push(addRow(newStart + y, newLines[newStart + y - 1]));
+		} else {
+			rows.push(removeRow(oldStart + x, oldLines[oldStart + x - 1]));
+		}
+		x = prevX;
+		y = prevY;
+	}
+
+	while (x > 0 && y > 0) {
+		rows.push(contextRow(oldStart + x, newStart + y, oldLines[oldStart + x - 1]));
+		x--;
+		y--;
+	}
+
+	rows.reverse();
+	return rows;
+}
+
+/**
+ * Diffs two texts line by line. Normalises `\r\n` to `\n` before splitting
+ * (uSync files get written on one OS and imported on another - without this
+ * a line-ending-only change would diff the whole file), trims the identical
+ * common prefix/suffix so large files with one changed line stay cheap, and
+ * degrades to a wholesale remove/add - bounded, honest output - rather than
+ * letting the O(ND) middle blow up.
+ */
+export function diffTextLines(oldText: string, newText: string): USyncLineDiffResult {
+	const oldLines = normalize(oldText).split('\n');
+	const newLines = normalize(newText).split('\n');
+
+	const minLen = Math.min(oldLines.length, newLines.length);
+
+	let prefix = 0;
+	while (prefix < minLen && oldLines[prefix] === newLines[prefix]) prefix++;
+
+	let suffix = 0;
+	while (
+		suffix < minLen - prefix &&
+		oldLines[oldLines.length - 1 - suffix] === newLines[newLines.length - 1 - suffix]
+	) {
+		suffix++;
+	}
+
+	const oldMidStart = prefix;
+	const oldMidEnd = oldLines.length - suffix;
+	const newMidStart = prefix;
+	const newMidEnd = newLines.length - suffix;
+
+	const oldMidLen = oldMidEnd - oldMidStart;
+	const newMidLen = newMidEnd - newMidStart;
+
+	let degraded = false;
+	let middleRows: USyncLineDiffRow[];
+
+	if (oldMidLen * newMidLen > USYNC_DIFF_LIMITS.maxLineDiffArea) {
+		degraded = true;
+		middleRows = wholesaleRows(
+			oldLines,
+			newLines,
+			oldMidStart,
+			oldMidEnd,
+			newMidStart,
+			newMidEnd,
+		);
+	} else {
+		const myers = myersDiff(
+			oldLines,
+			newLines,
+			oldMidStart,
+			oldMidEnd,
+			newMidStart,
+			newMidEnd,
+		);
+		if (myers === null) {
+			degraded = true;
+			middleRows = wholesaleRows(
+				oldLines,
+				newLines,
+				oldMidStart,
+				oldMidEnd,
+				newMidStart,
+				newMidEnd,
+			);
+		} else {
+			middleRows = myers;
+		}
+	}
+
+	const rows: USyncLineDiffRow[] = [];
+	for (let i = 0; i < prefix; i++) rows.push(contextRow(i + 1, i + 1, oldLines[i]));
+	rows.push(...middleRows);
+	for (let i = 0; i < suffix; i++) {
+		const oldLine = oldLines.length - suffix + i;
+		const newLine = newLines.length - suffix + i;
+		rows.push(contextRow(oldLine + 1, newLine + 1, oldLines[oldLine]));
+	}
+
+	return { oldLines, newLines, degraded, rows };
+}
+
+/**
+ * Collapses long runs of unchanged context rows down to a small lead-in/
+ * lead-out plus a single collapsed block, keeping the hidden rows so a
+ * consumer can splice them back in on click without re-diffing.
+ */
+export function collapseUnchanged(
+	rows: USyncLineDiffRow[],
+	context: number = USYNC_DIFF_LIMITS.lineContext,
+): USyncLineDiffBlock[] {
+	const blocks: USyncLineDiffBlock[] = [];
+	let i = 0;
+
+	while (i < rows.length) {
+		if (rows[i].type !== 'context') {
+			blocks.push({ type: 'row', row: rows[i] });
+			i++;
+			continue;
+		}
+
+		let end = i;
+		while (end < rows.length && rows[end].type === 'context') end++;
+		const run = rows.slice(i, end);
+
+		if (run.length <= 2 * context + 1) {
+			for (const row of run) blocks.push({ type: 'row', row });
+		} else {
+			const lead = run.slice(0, context);
+			const hidden = run.slice(context, run.length - context);
+			const trail = run.slice(run.length - context);
+			for (const row of lead) blocks.push({ type: 'row', row });
+			blocks.push({ type: 'collapsed', count: hidden.length, rows: hidden });
+			for (const row of trail) blocks.push({ type: 'row', row });
+		}
+
+		i = end;
+	}
+
+	return blocks;
+}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/types.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/utils/diff/types.ts
@@ -1,0 +1,76 @@
+export type USyncLeafChangeKind = 'added' | 'removed' | 'changed';
+
+export interface USyncLeafChange {
+	path: string; // "contentData[0: Hero].values[headline (en-US)]"
+	kind: USyncLeafChangeKind;
+	oldValue?: unknown;
+	newValue?: unknown;
+	expanded?: boolean; // path crossed into an encoded JSON string
+}
+
+export interface USyncJsonDiffResult {
+	changes: USyncLeafChange[];
+	totalCount: number; // before the cap
+	truncated: boolean;
+	/**
+	 * True when the walk aborted early on a runaway subtree, which makes
+	 * `totalCount` a floor rather than an exact count - report it as
+	 * "N or more changes".
+	 */
+	stopped: boolean;
+	reordered: string[]; // arrays whose contents matched but order changed
+}
+
+export type USyncDiffStrategy =
+	| 'skip'
+	| 'notice'
+	| 'masked'
+	| 'single'
+	| 'json'
+	| 'lines'
+	| 'words'
+	| 'scalar'
+	| 'oversized';
+
+export interface USyncClassifiedChange {
+	strategy: USyncDiffStrategy;
+	oldText: string;
+	newText: string;
+	oldJson?: unknown; // strategy === 'json' only
+	newJson?: unknown;
+	language: 'json' | 'xml' | 'text';
+	bytes: number;
+}
+
+export type USyncLineRowType = 'context' | 'add' | 'remove';
+
+export interface USyncLineDiffRow {
+	type: USyncLineRowType;
+	oldLine?: number;
+	newLine?: number;
+	text: string;
+}
+
+export interface USyncLineDiffResult {
+	oldLines: string[];
+	newLines: string[];
+	degraded: boolean;
+	rows: USyncLineDiffRow[];
+}
+
+export type USyncLineDiffBlock =
+	| { type: 'row'; row: USyncLineDiffRow }
+	| { type: 'collapsed'; count: number; rows: USyncLineDiffRow[] };
+
+// All thresholds in one exported const so they are tunable in one line.
+export const USYNC_DIFF_LIMITS = {
+	maxDiffBytes: 512_000, // above: raw only, no walk/diff at all
+	maxWordDiffBytes: 8_000, // diffWords is ~quadratic; also ~where a word diff stops being readable
+	maxScalarWordDiffBytes: 2_000,
+	inlineScalarChars: 80, // at or below: render inline as "old → new"
+	maxLeafChanges: 40,
+	maxJsonDepth: 12,
+	maxStringExpansions: 3,
+	maxLineDiffArea: 4_000_000, // |old| * |new| lines before degrading
+	lineContext: 3,
+} as const;


### PR DESCRIPTION
## Summary

- Replace the word-diffed, pretty-printed JSON in the change-detail view with a structured diff: each `USyncChange` is classified (masked, single-sided, JSON, XML/text lines, word, scalar) and rendered with the strategy that suits it, instead of running every value through `diffWords`.
- JSON/block values get a recursive leaf-change walk that matches array elements by identity (`key`/`udi`/`alias`+`culture`, with a fallback to index matching) so inserting one block in a block list reports one change, not a rewrite of the whole array.
- Long text/XML gets a hand-rolled line diff (Umbraco only re-exports `diffWords`, so no new dependency) with collapsed unchanged runs.
- The `uui-table` is replaced with a list of expandable rows so the diff gets the full width of the sidebar modal. A row starts open when it's the only change and collapsed once there's more than one; a failed (`success: false`) detail always forces itself open. Each JSON row has a "show raw values" toggle for the full old/new text.
- Fixes two accidental-precedence bugs (`length ?? 0 > 0` parses as `length ?? (0 > 0)`) and a case where `Error`/`Warning` notice details were being word-diffed against `''` instead of shown as a message.

All diff logic lives in dependency-free modules under `src/utils/diff/` (no imports from Lit or `@umbraco-cms/*`), so it can be exercised outside the backoffice; the identity-matching heuristic, JSON-string expansion, and line-diff bail-out behaviour were checked against fixtures in a throwaway harness before wiring up the component.

## Test plan

- [x] `npm run typescript:build` — clean
- [x] `npm run build` — succeeds
- [x] `npx prettier --check` on all changed files
- [x] In the backoffice: block list with one block inserted → one change reported, not a full rewrite
- [x] Block reorder only → reorder notice, no/few leaf changes
- [x] Culture-variant property → culture tag shown, not baked into the name
- [x] Masked value (member/user) → never diffed, shown as hidden
- [x] A failed import with error/warning details → notice shown, row open by default
- [x] Dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)