### PR TITLE
Publish nightly builds to the Jumoo nightly feed

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: windows-latest
     outputs:
       version_string: ${{ steps.gitversion.outputs.fullSemVer }}
+      major_minor_patch: ${{ steps.gitversion.outputs.majorMinorPatch }}
 
     steps:
       - name: Checkout
@@ -128,3 +129,33 @@ jobs:
         with:
           name: Nuget Build Output
           path: ${{env.OUT_FOLDER}}
+
+      - name: Pack for nightly feed
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/v17/main' }}
+        shell: pwsh
+        env:
+          nightly_version: ${{ needs.version.outputs.major_minor_patch }}-build.${{ github.run_number }}
+          nightly_out: ./nightly-out/
+        run: |
+          $projects = @(
+            "./uSync.Core/uSync.Core.csproj",
+            "./uSync.Backoffice/uSync.Backoffice.csproj",
+            "./uSync.Backoffice.Management.Api/uSync.Backoffice.Management.Api.csproj",
+            "./uSync.Backoffice.Management.Client/uSync.Backoffice.Management.Client.csproj",
+            "./uSync.Backoffice.Targets/uSync.Backoffice.Targets.csproj",
+            "./uSync.Community.Contrib/uSync.Community.Contrib.csproj",
+            "./uSync.Community.DataTypeSerializers/uSync.Community.DataTypeSerializers.csproj"
+          )
+          foreach ($project in $projects) {
+            dotnet pack $project -c ${{ env.config }} --output $env:nightly_out /p:version=$env:nightly_version
+          }
+
+      - name: Publish to nightly feed
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/v17/main' }}
+        uses: Jumoo/nightly-feed-config@main
+        with:
+          packages: ./nightly-out/
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
- Adds a step to `package-build.yml` that pushes every push-triggered build on `v17/main` to the shared Jumoo nightly feed (https://nightly.jumoo.uk), per `Jumoo/nightly-feed-config`.
- Exposes GitVersion's `majorMinorPatch` as a job output, since the nightly feed's mandated version scheme (`{version}-build.{increment}`) differs from the `fullSemVer` already used for the existing `build-out/` packages.
- Repacks the 7 shipped packages into a separate `./nightly-out/` folder stamped with `{majorMinorPatch}-build.{run_number}` (e.g. `17.3.9-build.42` off the current `v17.3.8` tag), then pushes via `Jumoo/nightly-feed-config@main` using the org-level `R2_*` secrets.
- Gated on `github.event_name == 'push' && github.ref == 'refs/heads/v17/main'` so a manual/workflow_dispatch rerun never publishes a real nightly build, and other branches matching the `*/main` trigger don't push to this repo's nightly line.

## Test plan
- [ ] Merge and confirm the `Pack for nightly feed` / `Publish to nightly feed` steps run and succeed on the next push to `v17/main`
- [ ] Confirm the new version appears at https://nightly.jumoo.uk/index.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)