### PR TITLE
Use a PAT to fetch nightly-feed-config outside the Jumoo org

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -150,9 +150,17 @@ jobs:
             dotnet pack $project -c ${{ env.config }} --output $env:nightly_out /p:version=$env:nightly_version
           }
 
+      - name: Checkout nightly-feed-config
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/v17/main' }}
+        uses: actions/checkout@v4
+        with:
+          repository: Jumoo/nightly-feed-config
+          token: ${{ secrets.NIGHTLY_FEED_PAT }}
+          path: .nightly-feed-config
+
       - name: Publish to nightly feed
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/v17/main' }}
-        uses: Jumoo/nightly-feed-config@main
+        uses: ./.nightly-feed-config
         with:
           packages: ./nightly-out/
         env:


### PR DESCRIPTION
## Summary
- `KevinJump/uSync` isn't in the Jumoo org, so `nightly-feed-config`'s organization-level Actions access (which lets in-org repos resolve `uses: Jumoo/nightly-feed-config@main` with just their own `GITHUB_TOKEN`) doesn't reach it.
- Adds a step that checks out `Jumoo/nightly-feed-config` locally using the new `NIGHTLY_FEED_PAT` secret (fine-grained, Contents: Read-only, scoped to that one repo), then runs the action by local path (`./.nightly-feed-config`) instead of the cross-org `uses:`.
- Requires the `NIGHTLY_FEED_PAT` and `R2_*` secrets to already exist on this repo (done — see the earlier setup steps).

## Test plan
- [ ] Confirm the `Checkout nightly-feed-config` and `Publish to nightly feed` steps succeed on the next push to `v17/main`
- [ ] Confirm the new version appears at https://nightly.jumoo.uk/index.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)