### PR TITLE
Pack the main uSync and uSync.History packages for the nightly feed

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -143,6 +143,8 @@ jobs:
             "./uSync.Backoffice.Management.Api/uSync.Backoffice.Management.Api.csproj",
             "./uSync.Backoffice.Management.Client/uSync.Backoffice.Management.Client.csproj",
             "./uSync.Backoffice.Targets/uSync.Backoffice.Targets.csproj",
+            "./uSync.History/uSync.History.csproj",
+            "./uSync/uSync.csproj",
             "./uSync.Community.Contrib/uSync.Community.Contrib.csproj",
             "./uSync.Community.DataTypeSerializers/uSync.Community.DataTypeSerializers.csproj"
           )


### PR DESCRIPTION
## Summary
- The nightly pack step only listed the sub-packages (`uSync.Core`, `uSync.Backoffice`, `uSync.Backoffice.Management.Api/.Client`, `uSync.Backoffice.Targets`, `uSync.Community.Contrib/.DataTypeSerializers`) — it never packed the top-level `uSync` meta-package, which is the one most consumers actually install.
- Adds `uSync/uSync.csproj` to the nightly pack list.
- Also adds `uSync.History/uSync.History.csproj`: `uSync.csproj` depends on it via `ProjectReference`, and since `uSync.History` carries its own `PackageId`, it needs its own nupkg on the nightly feed for that dependency to resolve — otherwise installing the nightly `uSync` package would fail to restore.

## Note for reviewer
The same gap (missing `uSync` and `uSync.History`) exists in this job's other pack list, the one that produces `build-out/` / the "Nuget Build Output" CI artifact. Left that alone since it's out of scope here — worth a follow-up if that artifact is used for anything beyond CI verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)