### PR TITLE
Remove duplicate nuget packaging in package-build workflow

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   config: Release
-  out_folder: ./build-out/
 
 jobs:
   version:
@@ -76,6 +75,9 @@ jobs:
 
     needs: [build-project, version]
 
+    env:
+      solution_name: ./uSync.slnx
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
@@ -102,33 +104,6 @@ jobs:
 
       - name: restore
         run: dotnet restore ${{ env.solution_name}} --locked-mode
-
-      - name: package uSync.Core
-        run: dotnet pack ./uSync.Core/uSync.Core.csproj -c ${{env.config}} --output ${{env.out_folder}} /p:version=${{ needs.version.outputs.version_string }}
-
-      - name: package uSync.Backoffice
-        run: dotnet pack ./uSync.Backoffice/uSync.Backoffice.csproj -c ${{env.config}} --output ${{env.out_folder}} /p:version=${{ needs.version.outputs.version_string }}
-
-      - name: package uSync.Backoffice.Management.Api
-        run: dotnet pack ./uSync.Backoffice.Management.Api/uSync.Backoffice.Management.Api.csproj -c ${{env.config}} --output ${{env.out_folder}} /p:version=${{ needs.version.outputs.version_string }}
-
-      - name: package uSync.Backoffice.Management.Client
-        run: dotnet pack ./uSync.Backoffice.Management.Client/uSync.Backoffice.Management.Client.csproj -c ${{env.config}} --output ${{env.out_folder}} /p:version=${{ needs.version.outputs.version_string }}
-
-      - name: package uSync.Backoffice.Targets
-        run: dotnet pack ./uSync.Backoffice.Targets/uSync.Backoffice.Targets.csproj -c ${{env.config}} --output ${{env.out_folder}} /p:version=${{ needs.version.outputs.version_string }}
-
-      - name: package uSync.Community.Contrib
-        run: dotnet pack ./uSync.Community.Contrib/uSync.Community.Contrib.csproj -c ${{env.config}} --output ${{env.out_folder}} /p:version=${{ needs.version.outputs.version_string }}
-
-      - name: package uSync.Community.DataTypeSerializers
-        run: dotnet pack ./uSync.Community.DataTypeSerializers/uSync.Community.DataTypeSerializers.csproj -c ${{env.config}} --output ${{env.out_folder}} /p:version=${{ needs.version.outputs.version_string }}
-
-      - name: Upload nuget file as build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: Nuget Build Output
-          path: ${{env.OUT_FOLDER}}
 
       - name: Pack for nightly feed
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/v17/main' }}


### PR DESCRIPTION
## Summary
- The `package-up` job in `.github/workflows/package-build.yml` was packing every project twice on each push to a `*/main` branch: once uploaded as a "Nuget Build Output" build artifact that was never consumed, then again with the nightly-versioned semver for the nightly feed.
- The first pack-and-upload block was actually broken anyway — the upload step referenced `${{env.OUT_FOLDER}}` while the env var was named `out_folder` (wrong casing), so the uploaded artifact was always empty.
- Removed the unused first pack block, the upload-artifact step, and the now-unused `out_folder` env var. Only the nightly packaging/publish path remains, unchanged.
- Also fixed the `restore` step above it, which referenced `${{ env.solution_name }}` without that env var being defined in the `package-up` job (it was only set in the separate `build-project` job, so job-level env doesn't carry across jobs and this restore was silently running against an empty path). Added `solution_name: ./uSync.slnx` to the job's `env`.

## Test plan
- [x] Validated the workflow YAML parses correctly
- [ ] Confirm the nightly feed publish step still runs correctly on the next push to `v17/main` in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)