### PR TITLE
Modernize workflow caching and cleanup

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,15 +1,17 @@
 name: "PR - Build and Test"
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request:
     branches: ["*/main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   config: Release
-  out_folder: ./build-out/
 
 jobs:
   build-project:

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: ["*/main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   config: Release
 
@@ -89,6 +93,12 @@ jobs:
       - name: version
         run: |
           echo "Version: ${{ needs.version.outputs.version_string}}"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: ./uSync.Backoffice.Management.Client/usync-assets/package-lock.json
 
       - name: Stamp version on NPM Package
         working-directory: ./uSync.Backoffice.Management.Client/usync-assets


### PR DESCRIPTION
## Summary
Stacked on #1074 (adds this on top of the already-fixed package-build.yml).

- **package-build.yml**: add `actions/setup-node@v4` (pinned to Node 24, `cache: npm` keyed on `usync-assets/package-lock.json`) before the `npm ci`/`npm run build` steps. Previously there was no Node setup step at all — builds relied on whatever Node version happened to be preinstalled on the `windows-latest` runner image, unpinned and with no dependency cache.
- **Both workflows**: added a `concurrency` group so a new push/PR update cancels a superseded in-flight run instead of letting it finish and queuing behind it — same pattern already applied to the CodeQL workflow.
- **dotnet-build.yml**: dropped the unused `pull-requests: write` permission (nothing in the workflow writes to a PR) and the dead `out_folder` env var (same unused-variable pattern that was fixed in package-build.yml).

## Note on concurrency + nightly publish
`package-build.yml`'s concurrency group can cancel an in-flight nightly-feed publish if another push lands on `v17/main` before it finishes. Each run publishes under a unique `nightly_version` (build number), so a cancelled run just means that specific nightly build doesn't make it to the feed — no partial/corrupt package state. Flagging it in case that trade-off isn't wanted.

## Test plan
- [x] Validated both workflow YAML files parse correctly
- [ ] Confirm `npm ci` cache hits on the next nightly build run

🤖 Generated with [Claude Code](https://claude.com/claude-code)