### PR TITLE
Fix cross-platform path handling and env casing bug found testing ubuntu-latest

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -40,4 +40,4 @@ jobs:
         run: dotnet test ${{ env.solution_name }}
 
       - name: Generate AppSettings Schema
-        run: dotnet run -c ${{env.Config}} --project ${{ env.schema_gen_project}}
+        run: dotnet run -c ${{ env.config }} --project ${{ env.schema_gen_project}}

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -72,7 +72,7 @@ jobs:
         run: dotnet test ${{ env.solution_name }}
 
       - name: Generate AppSettings Schema
-        run: dotnet run -c ${{env.Config}} --project ${{ env.schema_gen_project}}
+        run: dotnet run -c ${{ env.config }} --project ${{ env.schema_gen_project}}
 
   package-up:
     runs-on: windows-latest

--- a/uSync.Core/Extensions/StringExtensions.cs
+++ b/uSync.Core/Extensions/StringExtensions.cs
@@ -16,14 +16,22 @@ public static class StringExtensions
     /// <summary>
     ///  convert a file name to one that isn't going to cause us any downlevel problems.
     /// </summary>
+    /// <remarks>
+    ///  paths aren't always parsed on the OS they came from (e.g. a Windows-style path
+    ///  loaded on Linux), so we split on both separators here rather than using
+    ///  Path.GetFileName/GetDirectoryName, which only recognise the current OS's separator.
+    /// </remarks>
     public static string ToAppSafeFileName(this string value)
     {
-        var filename = Path.GetFileName(value);
+        var separatorIndex = value.LastIndexOfAny(['\\', '/']);
+        var directory = separatorIndex >= 0 ? value[..(separatorIndex + 1)] : string.Empty;
+        var filename = separatorIndex >= 0 ? value[(separatorIndex + 1)..] : value;
+
         if (_badNames.InvariantContains(filename))
         {
-            return Path.Combine(
-                Path.GetDirectoryName(value) ?? string.Empty,
-                $"__{Path.GetFileNameWithoutExtension(value)}__{Path.GetExtension(value)}");
+            var extension = Path.GetExtension(filename);
+            var nameWithoutExtension = filename[..^extension.Length];
+            return $"{directory}__{nameWithoutExtension}__{extension}";
         }
         return value;
     }


### PR DESCRIPTION
## Summary
While investigating whether the build/test workflows could move from `windows-latest` to `ubuntu-latest` runners (cheaper, and the code already targets net10.0 cross-platform), found and fixed two real bugs - both masked by Windows-specific behavior, unrelated to the actual runner-switch question:

1. **`StringExtensions.ToAppSafeFileName` didn't handle both path separators.** It used `Path.GetFileName`/`Path.GetDirectoryName`, which only recognize the current OS's separator. A Windows-style path (backslashes) passed to this method on Linux was returned completely untouched instead of having `app.config`/`web.config` renamed, because `GetFileName` found no `/` to split on and returned the whole string, so the bad-name check never matched. Now splits on both `\` and `/` manually so the result is the same regardless of which OS parses it. Caught by `PathNameTests.BadFileNamesAreAppended`, which failed on an ubuntu-latest test run but passes on windows-latest.

2. **`env.Config` casing bug in the "Generate AppSettings Schema" step**, present in both `dotnet-build.yml` and `package-build.yml`. The env var is defined as `config` (lowercase), but this one step referenced `${{env.Config}}`. This has silently worked forever because the Actions runner's `env` context is backed by the OS's real environment variables, and Windows env vars are case-insensitive - so it resolved fine on `windows-latest`. On `ubuntu-latest` the case-sensitive lookup returns nothing, `-c` ends up with no value, `dotnet run` swallows `--project` as if it were the value for `-c`, and the schema project is never found. Fixed both to use `${{ env.config }}`.

Both were found and verified via throwaway test branches/PRs against `ubuntu-latest` (since closed/deleted) - after these two fixes, the full workflow ran green end-to-end on `ubuntu-latest`. This PR itself does **not** change the runner OS - `windows-latest` is unchanged here. Whether to actually switch runners is a separate decision now that these blockers are cleared.

## Test plan
- [x] `dotnet test` passes locally (144/144, including the previously-failing `PathNameTests`)
- [x] Verified via a throwaway `ubuntu-latest` test PR that both fixes together produce a fully green run
- [x] Confirmed the fix doesn't change behavior on Windows (existing `GoodFileNamesAreNotChanged`/`BadFileNamesAreAppended` tests still pass unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)