### PR TITLE
[AMEND] Make bad file name list configurable

### DIFF
--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -211,7 +211,7 @@ namespace uSync.BackOffice.Configuration
         public bool DisableNotificationSuppression { get; set; } = false;
 
         /// <summary>
-        ///  trigger all the notifications in a background thread, 
+        ///  trigger all the notifications in a background thread,
         /// </summary>
         /// <remarks>
         ///  uSync will process imports faster, but any notification events will
@@ -219,5 +219,22 @@ namespace uSync.BackOffice.Configuration
         /// </remarks>
         [DefaultValue(false)]
         public bool BackgroundNotifications { get; set; } = false;
+
+        /// <summary>
+        ///  Additional file names (without path) that uSync should treat as unsafe
+        ///  and rename on export, appended to the built-in list ("app.config",
+        ///  "web.config").
+        /// </summary>
+        public string[] AdditionalBadNames { get; set; } = [];
+
+        /// <summary>
+        ///  When true, also treats the Windows reserved device names as unsafe
+        ///  file names on export (CON, PRN, AUX, NUL, COM1-9, LPT1-9, and their
+        ///  Unicode superscript variants COM¹-COM³/LPT¹-LPT³). Off by default
+        ///  because these names are only unsafe on Windows filesystems and most
+        ///  uSync deployments run on Linux, where they're ordinary filenames.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool IncludeWindowsReservedNames { get; set; } = false;
     }
 }

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1064,9 +1064,9 @@ namespace uSync.BackOffice.SyncHandlers
             var targetFolder = GetDirectoryForItem(item,folders, config);
 
             var filename = GetPath(targetFolder, item, config.GuidNames, config.UseFlatStructure)
-                .ToAppSafeFileName();
+                .ToAppSafeFileName(GetAdditionalBadNames());
 
-            // 
+            //
             if (IsLockedAtRoot(folders, filename.Substring(targetFolder.Length+1)))
             {
                 // if we have lock roots on, then this item will not export 
@@ -1686,7 +1686,7 @@ namespace uSync.BackOffice.SyncHandlers
             var targetFolder = GetDirectoryForItem(item,folders,config);
 
             var filename = GetPath(targetFolder, item, config.GuidNames, config.UseFlatStructure)
-                .ToAppSafeFileName();
+                .ToAppSafeFileName(GetAdditionalBadNames());
 
             if (IsLockedAtRoot(folders, filename.Substring(targetFolder.Length + 1)))
             {
@@ -2269,6 +2269,37 @@ namespace uSync.BackOffice.SyncHandlers
             => new EventMessage("Blocked", "You cannot make this change, root level items are locked", EventMessageType.Error);
 
 
+        /// <summary>
+        ///  cache of the merged additional-bad-names list, so it's built once per settings
+        ///  value rather than once per file during export (this runs per node).
+        /// </summary>
+        private uSyncSettings _additionalBadNamesSettings;
+        private string[] _additionalBadNamesCache;
+
+        /// <summary>
+        ///  additional file names (beyond the built-in app.config/web.config) that
+        ///  should be treated as unsafe on export, per uSyncSettings.
+        /// </summary>
+        private IEnumerable<string> GetAdditionalBadNames()
+        {
+            var settings = uSyncConfig.Settings;
+
+            // settings is replaced (not mutated) on config reload, so reference equality
+            // is enough to know the cached list is still valid.
+            if (!ReferenceEquals(settings, _additionalBadNamesSettings))
+            {
+                var additionalBadNames = settings.AdditionalBadNames ?? [];
+
+                _additionalBadNamesCache = settings.IncludeWindowsReservedNames
+                    ? additionalBadNames.Concat(global::uSync.Core.StringExtensions.GetWindowsReservedNames()).ToArray()
+                    : additionalBadNames;
+
+                _additionalBadNamesSettings = settings;
+            }
+
+            return _additionalBadNamesCache;
+        }
+
         private bool HasRootFolders()
             => syncFileService.AnyFolderExists(uSyncConfig.GetFolders()[..^1]);
 
@@ -2281,7 +2312,7 @@ namespace uSync.BackOffice.SyncHandlers
                     item,
                     DefaultConfig.GuidNames,
                     DefaultConfig.UseFlatStructure)
-                    .ToAppSafeFileName();
+                    .ToAppSafeFileName(GetAdditionalBadNames());
 
                 if (syncFileService.FileExists(filename))
                     return true;

--- a/uSync.Core/Extensions/StringExtensions.cs
+++ b/uSync.Core/Extensions/StringExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 using Umbraco.Extensions;
 
@@ -9,21 +11,69 @@ namespace uSync.Core
     {
 
         /// <summary>
-        ///  things can't be called web.config or app.config it causes issues on build and publish 
+        ///  things can't be called web.config or app.config it causes issues on build and publish
         /// </summary>
         private static readonly string[] BadNames = new[]
         {
             "app.config", "web.config"
         };
 
+        /// <summary>
+        ///  the windows reserved device names (and their unicode superscript variants).
+        /// </summary>
+        /// <remarks>
+        ///  built once (not regenerated per call) since this is invoked per-file during export.
+        /// </remarks>
+        private static readonly string[] WindowsReservedNames = BuildWindowsReservedNames();
+
+        private static string[] BuildWindowsReservedNames()
+        {
+            var names = new List<string> { "CON", "PRN", "AUX", "NUL" };
+            for (var i = 1; i <= 9; i++)
+            {
+                names.Add($"COM{i}");
+                names.Add($"LPT{i}");
+            }
+
+            // superscript variants Windows also reserves: COM¹ COM² COM³ / LPT¹ LPT² LPT³
+            foreach (var sup in new[] { '¹', '²', '³' })
+            {
+                names.Add($"COM{sup}");
+                names.Add($"LPT{sup}");
+            }
+
+            return names.ToArray();
+        }
+
+        /// <summary>
+        ///  the windows reserved device names (and their unicode superscript variants),
+        ///  generated rather than hand-typed so nothing gets missed. Computed once and cached.
+        /// </summary>
+        public static IEnumerable<string> GetWindowsReservedNames() => WindowsReservedNames;
+
         public static string ToAppSafeFileName(this string value)
+            => value.ToAppSafeFileName(Enumerable.Empty<string>());
+
+        /// <summary>
+        ///  as <see cref="ToAppSafeFileName(string)"/>, but also treats <paramref name="additionalBadNames"/>
+        ///  as unsafe file names (in addition to the built-in ones), so callers can extend the
+        ///  blocklist via configuration.
+        /// </summary>
+        public static string ToAppSafeFileName(this string value, IEnumerable<string> additionalBadNames)
         {
             var filename = Path.GetFileName(value);
-            if (BadNames.InvariantContains(filename))
+            var filenameWithoutExtension = Path.GetFileNameWithoutExtension(value);
+
+            var isBadName = BadNames.InvariantContains(filename)
+                || (additionalBadNames != null && (
+                    additionalBadNames.InvariantContains(filename)
+                    || additionalBadNames.InvariantContains(filenameWithoutExtension)));
+
+            if (isBadName)
             {
                 return Path.Combine(
                     Path.GetDirectoryName(value),
-                    $"__{Path.GetFileNameWithoutExtension(value)}__{Path.GetExtension(value)}");
+                    $"__{filenameWithoutExtension}__{Path.GetExtension(value)}");
             }
             return value;
         }

--- a/uSync.Tests/Extensions/PathNameTests.cs
+++ b/uSync.Tests/Extensions/PathNameTests.cs
@@ -31,6 +31,46 @@ namespace uSync.Tests.Extensions
             Assert.AreEqual(expected, value);
         }
 
+        [TestCase("c:\\website\\myfolder\\con.config")]
+        [TestCase("c:\\website\\myfolder\\CON.config")]
+        public void ReservedNamesAreNotChangedByDefault(string filename)
+        {
+            var value = filename.ToAppSafeFileName();
+
+            Assert.AreEqual(filename, value);
+        }
+
+        [TestCase("c:\\website\\myfolder\\readme.config", "c:\\website\\myfolder\\__readme__.config")]
+        [TestCase("c:\\website\\myfolder\\README.CONFIG", "c:\\website\\myfolder\\__README__.CONFIG")]
+        public void AdditionalBadNamesAreAppended(string filename, string expected)
+        {
+            var value = filename.ToAppSafeFileName(new[] { "readme.config" });
+
+            Assert.AreEqual(expected, value);
+        }
+
+        [TestCase("c:\\website\\myfolder\\CON.config", "c:\\website\\myfolder\\__CON__.config")]
+        [TestCase("c:\\website\\myfolder\\con.config", "c:\\website\\myfolder\\__con__.config")]
+        [TestCase("c:\\website\\myfolder\\COM1.config", "c:\\website\\myfolder\\__COM1__.config")]
+        [TestCase("c:\\website\\myfolder\\com9.config", "c:\\website\\myfolder\\__com9__.config")]
+        [TestCase("c:\\website\\myfolder\\LPT1.config", "c:\\website\\myfolder\\__LPT1__.config")]
+        [TestCase("c:\\website\\myfolder\\LPT9.config", "c:\\website\\myfolder\\__LPT9__.config")]
+        public void WindowsReservedNamesAreAppendedWhenIncluded(string filename, string expected)
+        {
+            var value = filename.ToAppSafeFileName(uSync.Core.StringExtensions.GetWindowsReservedNames());
+
+            Assert.AreEqual(expected, value);
+        }
+
+        [TestCase("c:\\website\\myfolder\\COM10.config")]
+        [TestCase("c:\\website\\myfolder\\LPT0.config")]
+        public void WindowsReservedNamesDoesNotOverreach(string filename)
+        {
+            var value = filename.ToAppSafeFileName(uSync.Core.StringExtensions.GetWindowsReservedNames());
+
+            Assert.AreEqual(filename, value);
+        }
+
         [TestCase("C:\\Source\\OpenSource\\v13\\uSync\\README.md", "\\OpenSource\\v13\\uSync")]
         [TestCase("C:\\Source\\OpenSource\\v13\\README.md", "\\Source\\OpenSource\\v13")]
         [TestCase("C:\\Source\\OpenSource\\README.md", "\\Source\\OpenSource")]


### PR DESCRIPTION
Adds AdditionalBadNames and IncludeWindowsReservedNames to uSyncSettings so the export-time unsafe-filename check (app.config/web.config) can be extended via appsettings.json, optionally including Windows reserved device names (CON, COM1-9, LPT1-9, etc). Built-in defaults stay active either way.

ToAppSafeFileName gets an additive overload taking the extra names so existing callers are unaffected. The merged list is cached per handler instance to avoid rebuilding it per exported node.

This resolves the issue #1083 for v13