### PR TITLE
[AMEND] Make bad file name blocklist configurable

### DIFF
--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -266,11 +266,28 @@ public class uSyncSettings
     public SyncProcessingMode ProcessingMode { get; set; } = SyncProcessingMode.Normal;
 
     /// <summary>
-    ///  location of the 'production' folder to use when in production mode, 
+    ///  location of the 'production' folder to use when in production mode,
     ///  or when creating the production mode files.
     /// </summary>
     [DefaultValue("uSync/production")]
     public string ProductionFolder { get; set; } = "uSync/production";
+
+    /// <summary>
+    ///  Additional file names (without path) that uSync should treat as unsafe
+    ///  and rename on export, appended to the built-in list ("app.config",
+    ///  "web.config").
+    /// </summary>
+    public string[] AdditionalBadNames { get; set; } = [];
+
+    /// <summary>
+    ///  When true, also treats the Windows reserved device names as unsafe
+    ///  file names on export (CON, PRN, AUX, NUL, COM1-9, LPT1-9, and their
+    ///  Unicode superscript variants COM¹-COM³/LPT¹-LPT³). Off by default
+    ///  because these names are only unsafe on Windows filesystems and most
+    ///  uSync deployments run on Linux, where they're ordinary filenames.
+    /// </summary>
+    [DefaultValue(false)]
+    public bool IncludeWindowsReservedNames { get; set; } = false;
 }
 
 /// <summary>

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -931,12 +931,12 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         var targetFolder = folders.Last();
 
         var filename = (await GetPathAsync(targetFolder, item, config.GuidNames, config.UseFlatStructure))
-            .ToAppSafeFileName();
+            .ToAppSafeFileName(GetAdditionalBadNames());
 
-        // 
+        //
         if (IsLockedAtRoot(folders, filename.Substring(targetFolder.Length + 1)))
         {
-            // if we have lock roots on, then this item will not export 
+            // if we have lock roots on, then this item will not export
             // because exporting would mean the root was no longer used.
             return [uSyncAction.SetAction(true, syncFileService.GetSiteRelativePath(filename),
                 type: typeof(TObject).ToString(),
@@ -1543,7 +1543,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
         var targetFolder = folders.Last();
         var filename = (await GetPathAsync(targetFolder, item, config.GuidNames, config.UseFlatStructure))
-            .ToAppSafeFileName();
+            .ToAppSafeFileName(GetAdditionalBadNames());
 
         if (IsLockedAtRoot(folders, filename.Substring(targetFolder.Length + 1)))
             return;
@@ -2146,7 +2146,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
                 item,
                 DefaultConfig.GuidNames,
                 DefaultConfig.UseFlatStructure))
-                .ToAppSafeFileName();
+                .ToAppSafeFileName(GetAdditionalBadNames());
 
             if (syncFileService.FileExists(filename))
                 return true;
@@ -2154,6 +2154,37 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         }
 
         return false;
+    }
+
+    /// <summary>
+    ///  cache of the merged additional-bad-names list, so it's built once per settings
+    ///  value rather than once per file during export (this runs per node).
+    /// </summary>
+    private uSyncSettings? _additionalBadNamesSettings;
+    private string[] _additionalBadNamesCache = [];
+
+    /// <summary>
+    ///  additional file names (beyond the built-in app.config/web.config) that
+    ///  should be treated as unsafe on export, per uSyncSettings.
+    /// </summary>
+    private IEnumerable<string> GetAdditionalBadNames()
+    {
+        var settings = uSyncConfig.Settings;
+
+        // settings is replaced (not mutated) on config reload, so reference equality
+        // is enough to know the cached list is still valid.
+        if (!ReferenceEquals(settings, _additionalBadNamesSettings))
+        {
+            var additionalBadNames = settings.AdditionalBadNames ?? [];
+
+            _additionalBadNamesCache = settings.IncludeWindowsReservedNames
+                ? [.. additionalBadNames, .. global::uSync.Core.StringExtensions.GetWindowsReservedNames()]
+                : additionalBadNames;
+
+            _additionalBadNamesSettings = settings;
+        }
+
+        return _additionalBadNamesCache;
     }
 
     #endregion

--- a/uSync.Core/Extensions/StringExtensions.cs
+++ b/uSync.Core/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Umbraco.Extensions;
 
 namespace uSync.Core;
@@ -6,12 +7,45 @@ namespace uSync.Core;
 public static class StringExtensions
 {
     /// <summary>
-    ///  things can't be called web.config or app.config it causes issues on build and publish 
+    ///  things can't be called web.config or app.config it causes issues on build and publish
     /// </summary>
     private static readonly string[] _badNames = [
         "app.config",
         "web.config"
     ];
+
+    /// <summary>
+    ///  the windows reserved device names (and their unicode superscript variants).
+    /// </summary>
+    /// <remarks>
+    ///  built once (not regenerated per call) since this is invoked per-file during export.
+    /// </remarks>
+    private static readonly string[] _windowsReservedNames = BuildWindowsReservedNames();
+
+    private static string[] BuildWindowsReservedNames()
+    {
+        var names = new List<string> { "CON", "PRN", "AUX", "NUL" };
+        for (var i = 1; i <= 9; i++)
+        {
+            names.Add($"COM{i}");
+            names.Add($"LPT{i}");
+        }
+
+        // superscript variants Windows also reserves: COM¹ COM² COM³ / LPT¹ LPT² LPT³
+        foreach (var sup in new[] { '¹', '²', '³' })
+        {
+            names.Add($"COM{sup}");
+            names.Add($"LPT{sup}");
+        }
+
+        return [.. names];
+    }
+
+    /// <summary>
+    ///  the windows reserved device names (and their unicode superscript variants),
+    ///  generated rather than hand-typed so nothing gets missed. Computed once and cached.
+    /// </summary>
+    public static IEnumerable<string> GetWindowsReservedNames() => _windowsReservedNames;
 
     /// <summary>
     ///  convert a file name to one that isn't going to cause us any downlevel problems.
@@ -22,15 +56,29 @@ public static class StringExtensions
     ///  Path.GetFileName/GetDirectoryName, which only recognise the current OS's separator.
     /// </remarks>
     public static string ToAppSafeFileName(this string value)
+        => value.ToAppSafeFileName([]);
+
+    /// <summary>
+    ///  as <see cref="ToAppSafeFileName(string)"/>, but also treats <paramref name="additionalBadNames"/>
+    ///  as unsafe file names (in addition to the built-in ones), so callers can extend the
+    ///  blocklist via configuration.
+    /// </summary>
+    public static string ToAppSafeFileName(this string value, IEnumerable<string> additionalBadNames)
     {
         var separatorIndex = value.LastIndexOfAny(['\\', '/']);
         var directory = separatorIndex >= 0 ? value[..(separatorIndex + 1)] : string.Empty;
         var filename = separatorIndex >= 0 ? value[(separatorIndex + 1)..] : value;
 
-        if (_badNames.InvariantContains(filename))
+        var extension = Path.GetExtension(filename);
+        var nameWithoutExtension = filename[..^extension.Length];
+
+        var isBadName = _badNames.InvariantContains(filename)
+            || (additionalBadNames != null && (
+                additionalBadNames.InvariantContains(filename)
+                || additionalBadNames.InvariantContains(nameWithoutExtension)));
+
+        if (isBadName)
         {
-            var extension = Path.GetExtension(filename);
-            var nameWithoutExtension = filename[..^extension.Length];
             return $"{directory}__{nameWithoutExtension}__{extension}";
         }
         return value;

--- a/uSync.Tests/Extensions/PathNameTests.cs
+++ b/uSync.Tests/Extensions/PathNameTests.cs
@@ -27,4 +27,44 @@ public class PathNameTests
 
         Assert.That(value, Is.EqualTo(expected));
     }
+
+    [TestCase("c:\\website\\myfolder\\con.config")]
+    [TestCase("c:\\website\\myfolder\\CON.config")]
+    public void ReservedNamesAreNotChangedByDefault(string filename)
+    {
+        var value = filename.ToAppSafeFileName();
+
+        Assert.That(value, Is.EqualTo(filename));
+    }
+
+    [TestCase("c:\\website\\myfolder\\readme.config", "c:\\website\\myfolder\\__readme__.config")]
+    [TestCase("c:\\website\\myfolder\\README.CONFIG", "c:\\website\\myfolder\\__README__.CONFIG")]
+    public void AdditionalBadNamesAreAppended(string filename, string expected)
+    {
+        var value = filename.ToAppSafeFileName(["readme.config"]);
+
+        Assert.That(value, Is.EqualTo(expected));
+    }
+
+    [TestCase("c:\\website\\myfolder\\CON.config", "c:\\website\\myfolder\\__CON__.config")]
+    [TestCase("c:\\website\\myfolder\\con.config", "c:\\website\\myfolder\\__con__.config")]
+    [TestCase("c:\\website\\myfolder\\COM1.config", "c:\\website\\myfolder\\__COM1__.config")]
+    [TestCase("c:\\website\\myfolder\\com9.config", "c:\\website\\myfolder\\__com9__.config")]
+    [TestCase("c:\\website\\myfolder\\LPT1.config", "c:\\website\\myfolder\\__LPT1__.config")]
+    [TestCase("c:\\website\\myfolder\\LPT9.config", "c:\\website\\myfolder\\__LPT9__.config")]
+    public void WindowsReservedNamesAreAppendedWhenIncluded(string filename, string expected)
+    {
+        var value = filename.ToAppSafeFileName(StringExtensions.GetWindowsReservedNames());
+
+        Assert.That(value, Is.EqualTo(expected));
+    }
+
+    [TestCase("c:\\website\\myfolder\\COM10.config")]
+    [TestCase("c:\\website\\myfolder\\LPT0.config")]
+    public void WindowsReservedNamesDoesNotOverreach(string filename)
+    {
+        var value = filename.ToAppSafeFileName(StringExtensions.GetWindowsReservedNames());
+
+        Assert.That(value, Is.EqualTo(filename));
+    }
 }


### PR DESCRIPTION
Adds AdditionalBadNames and IncludeWindowsReservedNames to uSyncSettings so the export-time unsafe-filename check (app.config/web.config) can be extended via appsettings.json, optionally including Windows reserved device names (CON, COM1-9, LPT1-9, etc). Built-in defaults stay active either way.

ToAppSafeFileName gets an additive overload taking the extra names so existing callers are unaffected. The merged list is cached per handler instance to avoid rebuilding it per exported node.

This resolves the issue #1083 for v17