### PR TITLE
Merge v17 into v18 (2026-09-12)

### DIFF
--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -294,11 +294,28 @@ public class uSyncSettings
     public SyncProcessingMode ProcessingMode { get; set; } = SyncProcessingMode.Normal;
 
     /// <summary>
-    ///  location of the 'production' folder to use when in production mode, 
+    ///  location of the 'production' folder to use when in production mode,
     ///  or when creating the production mode files.
     /// </summary>
     [DefaultValue("uSync/production")]
     public string ProductionFolder { get; set; } = "uSync/production";
+
+    /// <summary>
+    ///  Additional file names (without path) that uSync should treat as unsafe
+    ///  and rename on export, appended to the built-in list ("app.config",
+    ///  "web.config").
+    /// </summary>
+    public string[] AdditionalBadNames { get; set; } = [];
+
+    /// <summary>
+    ///  When true, also treats the Windows reserved device names as unsafe
+    ///  file names on export (CON, PRN, AUX, NUL, COM1-9, LPT1-9, and their
+    ///  Unicode superscript variants COM¹-COM³/LPT¹-LPT³). Off by default
+    ///  because these names are only unsafe on Windows filesystems and most
+    ///  uSync deployments run on Linux, where they're ordinary filenames.
+    /// </summary>
+    [DefaultValue(false)]
+    public bool IncludeWindowsReservedNames { get; set; } = false;
 }
 
 /// <summary>

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -966,12 +966,12 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         var targetFolder = folders.Last();
 
         var filename = (await GetPathAsync(targetFolder, item, config.GuidNames, config.UseFlatStructure))
-            .ToAppSafeFileName();
+            .ToAppSafeFileName(GetAdditionalBadNames());
 
-        // 
+        //
         if (IsLockedAtRoot(folders, filename.Substring(targetFolder.Length + 1)))
         {
-            // if we have lock roots on, then this item will not export 
+            // if we have lock roots on, then this item will not export
             // because exporting would mean the root was no longer used.
             return [uSyncAction.SetAction(true, syncFileService.GetSiteRelativePath(filename),
                 type: typeof(TObject).ToString(),
@@ -1587,7 +1587,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
         var targetFolder = folders.Last();
         var filename = (await GetPathAsync(targetFolder, item, config.GuidNames, config.UseFlatStructure))
-            .ToAppSafeFileName();
+            .ToAppSafeFileName(GetAdditionalBadNames());
 
         if (IsLockedAtRoot(folders, filename.Substring(targetFolder.Length + 1)))
             return;
@@ -2206,7 +2206,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
                 item,
                 DefaultConfig.GuidNames,
                 DefaultConfig.UseFlatStructure))
-                .ToAppSafeFileName();
+                .ToAppSafeFileName(GetAdditionalBadNames());
 
             if (syncFileService.FileExists(filename))
                 return true;
@@ -2214,6 +2214,37 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         }
 
         return false;
+    }
+
+    /// <summary>
+    ///  cache of the merged additional-bad-names list, so it's built once per settings
+    ///  value rather than once per file during export (this runs per node).
+    /// </summary>
+    private uSyncSettings? _additionalBadNamesSettings;
+    private string[] _additionalBadNamesCache = [];
+
+    /// <summary>
+    ///  additional file names (beyond the built-in app.config/web.config) that
+    ///  should be treated as unsafe on export, per uSyncSettings.
+    /// </summary>
+    private IEnumerable<string> GetAdditionalBadNames()
+    {
+        var settings = uSyncConfig.Settings;
+
+        // settings is replaced (not mutated) on config reload, so reference equality
+        // is enough to know the cached list is still valid.
+        if (!ReferenceEquals(settings, _additionalBadNamesSettings))
+        {
+            var additionalBadNames = settings.AdditionalBadNames ?? [];
+
+            _additionalBadNamesCache = settings.IncludeWindowsReservedNames
+                ? [.. additionalBadNames, .. global::uSync.Core.StringExtensions.GetWindowsReservedNames()]
+                : additionalBadNames;
+
+            _additionalBadNamesSettings = settings;
+        }
+
+        return _additionalBadNamesCache;
     }
 
     #endregion

--- a/uSync.Core/Extensions/StringExtensions.cs
+++ b/uSync.Core/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Umbraco.Extensions;
 
 namespace uSync.Core;
@@ -6,12 +7,45 @@ namespace uSync.Core;
 public static class StringExtensions
 {
     /// <summary>
-    ///  things can't be called web.config or app.config it causes issues on build and publish 
+    ///  things can't be called web.config or app.config it causes issues on build and publish
     /// </summary>
     private static readonly string[] _badNames = [
         "app.config",
         "web.config"
     ];
+
+    /// <summary>
+    ///  the windows reserved device names (and their unicode superscript variants).
+    /// </summary>
+    /// <remarks>
+    ///  built once (not regenerated per call) since this is invoked per-file during export.
+    /// </remarks>
+    private static readonly string[] _windowsReservedNames = BuildWindowsReservedNames();
+
+    private static string[] BuildWindowsReservedNames()
+    {
+        var names = new List<string> { "CON", "PRN", "AUX", "NUL" };
+        for (var i = 1; i <= 9; i++)
+        {
+            names.Add($"COM{i}");
+            names.Add($"LPT{i}");
+        }
+
+        // superscript variants Windows also reserves: COM¹ COM² COM³ / LPT¹ LPT² LPT³
+        foreach (var sup in new[] { '¹', '²', '³' })
+        {
+            names.Add($"COM{sup}");
+            names.Add($"LPT{sup}");
+        }
+
+        return [.. names];
+    }
+
+    /// <summary>
+    ///  the windows reserved device names (and their unicode superscript variants),
+    ///  generated rather than hand-typed so nothing gets missed. Computed once and cached.
+    /// </summary>
+    public static IEnumerable<string> GetWindowsReservedNames() => _windowsReservedNames;
 
     /// <summary>
     ///  convert a file name to one that isn't going to cause us any downlevel problems.
@@ -22,15 +56,29 @@ public static class StringExtensions
     ///  Path.GetFileName/GetDirectoryName, which only recognise the current OS's separator.
     /// </remarks>
     public static string ToAppSafeFileName(this string value)
+        => value.ToAppSafeFileName([]);
+
+    /// <summary>
+    ///  as <see cref="ToAppSafeFileName(string)"/>, but also treats <paramref name="additionalBadNames"/>
+    ///  as unsafe file names (in addition to the built-in ones), so callers can extend the
+    ///  blocklist via configuration.
+    /// </summary>
+    public static string ToAppSafeFileName(this string value, IEnumerable<string> additionalBadNames)
     {
         var separatorIndex = value.LastIndexOfAny(['\\', '/']);
         var directory = separatorIndex >= 0 ? value[..(separatorIndex + 1)] : string.Empty;
         var filename = separatorIndex >= 0 ? value[(separatorIndex + 1)..] : value;
 
-        if (_badNames.InvariantContains(filename))
+        var extension = Path.GetExtension(filename);
+        var nameWithoutExtension = filename[..^extension.Length];
+
+        var isBadName = _badNames.InvariantContains(filename)
+            || (additionalBadNames != null && (
+                additionalBadNames.InvariantContains(filename)
+                || additionalBadNames.InvariantContains(nameWithoutExtension)));
+
+        if (isBadName)
         {
-            var extension = Path.GetExtension(filename);
-            var nameWithoutExtension = filename[..^extension.Length];
             return $"{directory}__{nameWithoutExtension}__{extension}";
         }
         return value;

--- a/uSync.Tests/Extensions/PathNameTests.cs
+++ b/uSync.Tests/Extensions/PathNameTests.cs
@@ -27,4 +27,44 @@ public class PathNameTests
 
         Assert.That(value, Is.EqualTo(expected));
     }
+
+    [TestCase("c:\\website\\myfolder\\con.config")]
+    [TestCase("c:\\website\\myfolder\\CON.config")]
+    public void ReservedNamesAreNotChangedByDefault(string filename)
+    {
+        var value = filename.ToAppSafeFileName();
+
+        Assert.That(value, Is.EqualTo(filename));
+    }
+
+    [TestCase("c:\\website\\myfolder\\readme.config", "c:\\website\\myfolder\\__readme__.config")]
+    [TestCase("c:\\website\\myfolder\\README.CONFIG", "c:\\website\\myfolder\\__README__.CONFIG")]
+    public void AdditionalBadNamesAreAppended(string filename, string expected)
+    {
+        var value = filename.ToAppSafeFileName(["readme.config"]);
+
+        Assert.That(value, Is.EqualTo(expected));
+    }
+
+    [TestCase("c:\\website\\myfolder\\CON.config", "c:\\website\\myfolder\\__CON__.config")]
+    [TestCase("c:\\website\\myfolder\\con.config", "c:\\website\\myfolder\\__con__.config")]
+    [TestCase("c:\\website\\myfolder\\COM1.config", "c:\\website\\myfolder\\__COM1__.config")]
+    [TestCase("c:\\website\\myfolder\\com9.config", "c:\\website\\myfolder\\__com9__.config")]
+    [TestCase("c:\\website\\myfolder\\LPT1.config", "c:\\website\\myfolder\\__LPT1__.config")]
+    [TestCase("c:\\website\\myfolder\\LPT9.config", "c:\\website\\myfolder\\__LPT9__.config")]
+    public void WindowsReservedNamesAreAppendedWhenIncluded(string filename, string expected)
+    {
+        var value = filename.ToAppSafeFileName(StringExtensions.GetWindowsReservedNames());
+
+        Assert.That(value, Is.EqualTo(expected));
+    }
+
+    [TestCase("c:\\website\\myfolder\\COM10.config")]
+    [TestCase("c:\\website\\myfolder\\LPT0.config")]
+    public void WindowsReservedNamesDoesNotOverreach(string filename)
+    {
+        var value = filename.ToAppSafeFileName(StringExtensions.GetWindowsReservedNames());
+
+        Assert.That(value, Is.EqualTo(filename));
+    }
 }


### PR DESCRIPTION
## Summary

Forward-ports the v17 work landed after the last forward merge (#1081)
that was still outstanding.

- **Configurable bad file name blocklist** — cherry-picked from
  [#1085](https://github.com/Jumoo/uSync/pull/1085): adds
  `AdditionalBadNames`/`IncludeWindowsReservedNames` to `uSyncSettings` so
  the export-time unsafe-filename check can be extended via
  `appsettings.json`, optionally including Windows reserved device names.
  `ToAppSafeFileName` gets an additive overload taking the extra names.
  Applied cleanly on top of the `ToAppSafeFileName` fix already ported in
  #1081.

**Not ported** (judgement call, left for a separate decision):
- [#1082](https://github.com/Jumoo/uSync/pull/1082) "Convert nightly
  build workflow to manual prerelease trigger" — renames v17's
  `package-build.yml` to `prerelease.yml` and switches its trigger to
  `workflow_dispatch`. v18's `package-build.yml` is still push-triggered
  but was already independently modernized past v17's CI in #1081, so
  this is being held back rather than ported automatically.

## Test plan

- [x] `dotnet build ./uSync.slnx -c Release` — succeeds, 0 errors
- [x] `dotnet test ./uSync.Tests/uSync.Tests.csproj -c Release` — 230/230 passed

Please merge with a **merge commit**, not squash, so the next forward-port
run can find this baseline directly from ancestry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)